### PR TITLE
major changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+all:
+	r.js -o build.js
+clean: jcx.compiled.js
+	rm jcx.compiled.js

--- a/build.js
+++ b/build.js
@@ -1,0 +1,5 @@
+({
+    baseUrl: "src",
+    name:"main",
+    out: "jcx.compiled.js"
+})

--- a/demos/app.js
+++ b/demos/app.js
@@ -1,13 +1,13 @@
 define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape', 'jcx/StaticText'],function(Stage, Sprite, Shape, StaticText){
-	function setupCanvasStyles(canvas, document) {
-		canvas.width = document.width;
-		canvas.height = document.height;
+    function setupCanvasStyles(canvas, document) {
+        canvas.width = document.width;
+        canvas.height = document.height;
 
-		canvas.style.width = canvas.width;
-		canvas.style.height = canvas.height;
-		canvas.style.backgroundColor = "#333333";
+        canvas.style.width = canvas.width;
+        canvas.style.height = canvas.height;
+        canvas.style.backgroundColor = "#333333";
         canvas.style.position = "relative";
-	}
+    }
 
     function logSpriteClick(e){
         var logString = e.target.name + " clicked: x "+ e.target.stageX +" y " + e.target.stageY + "\n";
@@ -51,6 +51,17 @@ define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape', 'jcx/StaticText'],function(Stage
         sprite.height = 100;
         sprite.name = "lonely sprite";
         sprite.onclick = logSpriteClick;
+        
+        sprite.onmousedown = function(e){
+            e.target.startDrag();
+        };
+        sprite.onmouseup = function(e){
+            e.target.stopDrag();
+        };
+        sprite.onmousemove = function(e){
+            e.target.stageX = e.stageX - 10;
+            e.target.stageY = e.stageY - 10;
+        };
 
         var shape1 = new Shape();
         shape1.name = "red square";
@@ -65,7 +76,7 @@ define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape', 'jcx/StaticText'],function(Stage
 
         sprite.addChild(shape1);
         stage.addChild(sprite);
-
+        
         var staticText = new StaticText();
         staticText.x = 5;
         staticText.y = 20;
@@ -158,7 +169,7 @@ define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape', 'jcx/StaticText'],function(Stage
         stage.addChild(sprite2);
 
         loop(stage);
-	}
+    }
     
     function loop(stage){
         stage.draw();

--- a/demos/app.js
+++ b/demos/app.js
@@ -36,10 +36,10 @@ window.app = (function(){
 			stage.addChild(sprite);
 
 			var sprite2 = new Sprite(120, 10, function(context) {
-				context.drawSquare(0, 0, 100, "#FFF", "#00FF00");
-				context.drawSquare(10, 10, 20, "#333", "#00FF00");
+				context.drawSquare(0, 0, 100, "#FFF", "#FFFF00");
+				context.drawSquare(10, 10, 20, "#333", "#FF0000");
 				context.drawSquare(20, 20, 20, "#333", "#00FF00");
-				context.drawSquare(30, 30, 20, "#333", "#00FF00");
+				context.drawSquare(30, 30, 20, "#333", "#0000FF");
 			},
 			function(x,y){
 				return (x >= this.x && x <= this.x+100) && (y >= this.y && y <= this.y+100);

--- a/demos/app.js
+++ b/demos/app.js
@@ -8,6 +8,12 @@ define(['jcx', 'jcx/Stage', 'jcx/sprite'],function(JCX, Stage, Sprite){
 		canvas.style.backgroundColor = "#333333";
 	}
 
+    function logSpriteClick(e){
+        var logString = "Sprite " + e.target.name + " clicked\n";
+        logString += "Mouse Location:\nx " + e.stageX + " y " + e.stageY;
+        console.log(logString);
+    }
+
     function init() {
         var canvas, context, stage;
 
@@ -22,9 +28,8 @@ define(['jcx', 'jcx/Stage', 'jcx/sprite'],function(JCX, Stage, Sprite){
         function(x,y){
             return (x >= this.x && x <= this.x+100) && (y >= this.y && y <= this.y+100);
         });
-        sprite.onclick = function(e) {
-            console.log("Sprite 1 was clicked : " + e.target.x + ", " + e.target.y);
-        };
+        sprite.name = "lonely sprite";
+        sprite.onclick = logSpriteClick;
         stage.addChild(sprite);
 
         var sprite2 = new Sprite(120, 10, function(context) {
@@ -33,11 +38,10 @@ define(['jcx', 'jcx/Stage', 'jcx/sprite'],function(JCX, Stage, Sprite){
             context.drawSquare(30, 30, 20, "#333", "#0000FF");
         },
         function(x,y){
-            return (x >= this.x && x <= this.x+100) && (y >= this.y && y <= this.y+100);
+            return (x >= this.x && x <= this.x + 100) && (y >= this.y && y <= this.y + 100);
         });
-        sprite2.onclick = function(e) {
-            console.log("Sprite 2 was clicked : " + e.target.x + ", " + e.target.y);
-        };
+        sprite2.name = "nesting sprite";
+        sprite2.onclick = logSpriteClick;
 
         var sprite3 = new Sprite(10, 10, function(context){
             context.drawCircle(10,10,10, "#333","#00FFFF");
@@ -48,9 +52,8 @@ define(['jcx', 'jcx/Stage', 'jcx/sprite'],function(JCX, Stage, Sprite){
             var c_squared = a_squared + b_squared;
             return c_squared < 100;
         });
-        sprite3.onclick = function(e){
-            console.log("Sprite 3 was clicked : " + e.target.x + ", " + e.target.y);
-        };
+        sprite3.name = "nested sprite";
+        sprite3.onclick = logSpriteClick;
         stage.addChild(sprite2);
 
         sprite2.addChild(sprite3);

--- a/demos/app.js
+++ b/demos/app.js
@@ -29,7 +29,7 @@ define(['jcx/Stage', 'jcx/sprite'],function(Stage, Sprite){
             return (x >= this.x && x <= this.x+100) && (y >= this.y && y <= this.y+100);
         });
         sprite.onclick = function(e) {
-            console.log("Sprite 1 was clicked : " + e.source.x + ", " + e.source.y);
+            console.log("Sprite 1 was clicked : " + e.target.x + ", " + e.target.y);
         };
         stage.addChild(sprite);
 
@@ -43,7 +43,7 @@ define(['jcx/Stage', 'jcx/sprite'],function(Stage, Sprite){
             return (x >= this.x && x <= this.x+100) && (y >= this.y && y <= this.y+100);
         });
         sprite2.onclick = function(e) {
-            console.log("Sprite 2 was clicked : " + e.source.x + ", " + e.source.y);
+            console.log("Sprite 2 was clicked : " + e.target.x + ", " + e.target.y);
         };
         stage.addChild(sprite2);
 

--- a/demos/app.js
+++ b/demos/app.js
@@ -1,7 +1,7 @@
 define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape', 'jcx/StaticText'],function(Stage, Sprite, Shape, StaticText){
     function setupCanvasStyles(canvas, document) {
-        canvas.width = document.width;
-        canvas.height = document.height;
+        canvas.width = document.body.clientWidth;
+        canvas.height = document.body.clientHeight;
 
         canvas.style.width = canvas.width;
         canvas.style.height = canvas.height;

--- a/demos/app.js
+++ b/demos/app.js
@@ -63,8 +63,8 @@ define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape', 'jcx/StaticText'],function(Stage
         stage.addChild(sprite);
 
         var staticText = new StaticText();
-        staticText.x = 10;
-        staticText.y = 10;
+        staticText.x = 5;
+        staticText.y = 20;
         staticText.color = "#FFFFFF";
         staticText.text = "Hello World!";
         staticText.renderer = renderText;
@@ -145,6 +145,5 @@ define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape', 'jcx/StaticText'],function(Stage
         stage.draw();
 	}
 
-    window.onload = init;
     return init;
 });

--- a/demos/app.js
+++ b/demos/app.js
@@ -1,5 +1,4 @@
-window.app = (function(){
-
+define(['jcx/Stage', 'jcx/sprite'],function(Stage, Sprite){
 	function testSquare(context) {
 		jcx.drawSquare(context, 10, 10, 100, "#FFF");
 		jcx.drawSquare(context, 120, 10, 100, "#FFF","#EEE");
@@ -15,45 +14,42 @@ window.app = (function(){
 		canvas.style.backgroundColor = "#333333";
 	}
 
-	return {
-		init: function() {
-			var canvas, context, stage;
+    function init() {
+        var canvas, context, stage;
 
-			canvas = document.getElementById("theCanvas");
+        canvas = document.getElementById("theCanvas");
 
-			setupCanvasStyles(canvas, document);
-			stage = new Stage(canvas);
+        setupCanvasStyles(canvas, document);
+        stage = new Stage(canvas);
 
-			var sprite = new Sprite(10, 10, function(context) {
-				context.drawSquare(0, 0, 100, "#FFF", "#FF0000");
-			},
-			function(x,y){
-				return (x >= this.x && x <= this.x+100) && (y >= this.y && y <= this.y+100);
-			});
-			sprite.onclick = function(e) {
-				console.log("Sprite 1 was clicked : " + e.source.x + ", " + e.source.y);
-			};
-			stage.addChild(sprite);
+        var sprite = new Sprite(10, 10, function(context) {
+            context.drawSquare(0, 0, 100, "#FFF", "#FF0000");
+        },
+        function(x,y){
+            return (x >= this.x && x <= this.x+100) && (y >= this.y && y <= this.y+100);
+        });
+        sprite.onclick = function(e) {
+            console.log("Sprite 1 was clicked : " + e.source.x + ", " + e.source.y);
+        };
+        stage.addChild(sprite);
 
-			var sprite2 = new Sprite(120, 10, function(context) {
-				context.drawSquare(0, 0, 100, "#FFF", "#FFFF00");
-				context.drawSquare(10, 10, 20, "#333", "#FF0000");
-				context.drawSquare(20, 20, 20, "#333", "#00FF00");
-				context.drawSquare(30, 30, 20, "#333", "#0000FF");
-			},
-			function(x,y){
-				return (x >= this.x && x <= this.x+100) && (y >= this.y && y <= this.y+100);
-			});
-			sprite2.onclick = function(e) {
-				console.log("Sprite 2 was clicked : " + e.source.x + ", " + e.source.y);
-			};
-			stage.addChild(sprite2); 
+        var sprite2 = new Sprite(120, 10, function(context) {
+            context.drawSquare(0, 0, 100, "#FFF", "#FFFF00");
+            context.drawSquare(10, 10, 20, "#333", "#FF0000");
+            context.drawSquare(20, 20, 20, "#333", "#00FF00");
+            context.drawSquare(30, 30, 20, "#333", "#0000FF");
+        },
+        function(x,y){
+            return (x >= this.x && x <= this.x+100) && (y >= this.y && y <= this.y+100);
+        });
+        sprite2.onclick = function(e) {
+            console.log("Sprite 2 was clicked : " + e.source.x + ", " + e.source.y);
+        };
+        stage.addChild(sprite2);
 
-			stage.draw();
-		}
+        stage.draw();
+	}
 
-	};
-
-}());
-
-window.onload = window.app.init;
+    window.onload = init;
+    return init;
+});

--- a/demos/app.js
+++ b/demos/app.js
@@ -1,4 +1,4 @@
-define(['jcx', 'jcx/Stage', 'jcx/sprite'],function(JCX, Stage, Sprite){
+define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape'],function(Stage, Sprite, Shape){
 	function setupCanvasStyles(canvas, document) {
 		canvas.width = document.width;
 		canvas.height = document.height;
@@ -6,12 +6,27 @@ define(['jcx', 'jcx/Stage', 'jcx/sprite'],function(JCX, Stage, Sprite){
 		canvas.style.width = canvas.width;
 		canvas.style.height = canvas.height;
 		canvas.style.backgroundColor = "#333333";
+        canvas.style.position = "relative";
 	}
 
     function logSpriteClick(e){
         var logString = "Sprite " + e.target.name + " clicked\n";
         logString += "Mouse Location:\nx " + e.stageX + " y " + e.stageY;
         console.log(logString);
+    }
+
+    function inBoundsOfRect(x, y){
+        return (x >= this.stageX && x <= this.stageX+this.width) && (y >= this.stageY && y <= this.stageY+this.height);
+    }
+
+    function inBoundsOfCircle(x,y){
+        var a_squared = Math.pow(this.stageX - x, 2);
+        var b_squared = Math.pow(this.stageY - y, 2);
+        var c_squared = a_squared + b_squared;
+        return c_squared < 100;
+    }
+    function renderSquare(context){
+        context.drawSquare(this.stageX, this.stageY, this.width, "#333", this.color);
     }
 
     function init() {
@@ -22,41 +37,99 @@ define(['jcx', 'jcx/Stage', 'jcx/sprite'],function(JCX, Stage, Sprite){
         setupCanvasStyles(canvas, document);
         stage = new Stage(canvas);
 
-        var sprite = new Sprite(10,10,function(context) {
-            context.drawSquare(0, 0, 100, "#FFF", "#FF0000");
-        },
-        function(x,y){
-            return (x >= this.x && x <= this.x+100) && (y >= this.y && y <= this.y+100);
-        });
+        var sprite = new Sprite();
+        sprite.x = 10;
+        sprite.y = 10;
+        sprite.width = 100;
+        sprite.height = 100;
         sprite.name = "lonely sprite";
         sprite.onclick = logSpriteClick;
+
+        var shape1 = new Shape();
+        shape1.name = "red square";
+        shape1.x = 0;
+        shape1.y = 0;
+        shape1.width = 100;
+        shape1.height = 100;
+        shape1.color = "#FF0000";
+        shape1.renderer = renderSquare;
+        shape1.isInBoundsTester = inBoundsOfRect;
+        shape1.onclick = logSpriteClick;
+
+        sprite.addChild(shape1);
         stage.addChild(sprite);
 
-        var sprite2 = new Sprite(120, 10, function(context) {
-            context.drawSquare(0, 0, 100, "#FFF", "#FFFF00");
-            context.drawSquare(20, 20, 20, "#333", "#00FF00");
-            context.drawSquare(30, 30, 20, "#333", "#0000FF");
-        },
-        function(x,y){
-            return (x >= this.x && x <= this.x + 100) && (y >= this.y && y <= this.y + 100);
-        });
+        var sprite2 = new Sprite();
+        sprite2.x = 120;
+        sprite2.y = 10;
+        sprite2.width = 100;
+        sprite2.height = 100;
         sprite2.name = "nesting sprite";
         sprite2.onclick = logSpriteClick;
 
-        var sprite3 = new Sprite(10, 10, function(context){
-            context.drawCircle(10,10,10, "#333","#00FFFF");
-        },
-        function(x,y){
-            var a_squared = Math.pow(this.jcx.xOffset + this.x - x, 2);
-            var b_squared = Math.pow(this.jcx.yOffset + this.y - y, 2);
-            var c_squared = a_squared + b_squared;
-            return c_squared < 100;
-        });
+        var shape2 = new Shape();
+        shape2.name = "yellow square";
+        shape2.x = 0;
+        shape2.y = 0;
+        shape2.width = 100;
+        shape2.height = 100;
+        shape2.color = "#FFFF00";
+        shape2.renderer = renderSquare;
+        shape2.isInBoundsTester = inBoundsOfRect;
+        shape2.onclick = logSpriteClick;
+        
+        var shape3 = new Shape();
+        shape3.name = "green square";
+        shape3.x = 20;
+        shape3.y = 20;
+        shape3.width=20;
+        shape3.height=20;
+        shape3.color = "#00FF00";
+        shape3.renderer = renderSquare;
+        shape3.isInBoundsTester = inBoundsOfRect;
+        shape3.onclick = logSpriteClick;
+
+        var shape4 = new Shape();
+        shape4.name = "blue square";
+        shape4.x = 30;
+        shape4.y = 30;
+        shape4.width = 20;
+        shape4.height = 20;
+        shape4.color = "#0000FF";
+        shape4.renderer = renderSquare;
+        shape4.isInBoundsTester = inBoundsOfRect;
+        shape4.onclick = logSpriteClick;
+
+        var sprite3 = new Sprite();
+        sprite3.x = 20;
+        sprite3.y = 20;
+        sprite3.width = 20;
+        sprite3.height = 20;
         sprite3.name = "nested sprite";
         sprite3.onclick = logSpriteClick;
-        stage.addChild(sprite2);
+        sprite3._isInBounds = inBoundsOfCircle;
 
+        var shape5 = new Shape();
+        shape5.name = "cyan circle";
+        shape5.x = 0;
+        shape5.y = 0;
+        shape5.width = 20;
+        shape5.height = 20;
+        shape5.color = "#00FFFF";
+        shape5.renderer = function(context){
+            context.drawCircle(this.stageX, this.stageY,10, "#333",this.color);
+        };
+        shape5.isInBoundsTester = inBoundsOfCircle;
+        shape5.onclick = logSpriteClick;
+        
+        sprite3.addChild(shape5);
+        
+        sprite2.addChild(shape2);
         sprite2.addChild(sprite3);
+        sprite2.addChild(shape3);
+        sprite2.addChild(shape4);
+
+        stage.addChild(sprite2);
 
         stage.draw();
 	}

--- a/demos/app.js
+++ b/demos/app.js
@@ -1,4 +1,4 @@
-define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape'],function(Stage, Sprite, Shape){
+define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape', 'jcx/StaticText'],function(Stage, Sprite, Shape, StaticText){
 	function setupCanvasStyles(canvas, document) {
 		canvas.width = document.width;
 		canvas.height = document.height;
@@ -10,8 +10,8 @@ define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape'],function(Stage, Sprite, Shape){
 	}
 
     function logSpriteClick(e){
-        var logString = "Sprite " + e.target.name + " clicked\n";
-        logString += "Mouse Location:\nx " + e.stageX + " y " + e.stageY;
+        var logString = e.target.name + " clicked: x "+ e.target.stageX +" y " + e.target.stageY + "\n";
+        logString += "mouse location: x " + e.stageX + " y " + e.stageY;
         console.log(logString);
     }
 
@@ -27,6 +27,9 @@ define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape'],function(Stage, Sprite, Shape){
     }
     function renderSquare(context){
         context.drawSquare(this.stageX, this.stageY, this.width, "#333", this.color);
+    }
+    function renderText(context){
+        context.drawText(this.stageX, this.stageY, this.text, "#333", this.color);
     }
 
     function init() {
@@ -58,6 +61,14 @@ define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape'],function(Stage, Sprite, Shape){
 
         sprite.addChild(shape1);
         stage.addChild(sprite);
+
+        var staticText = new StaticText();
+        staticText.x = 10;
+        staticText.y = 10;
+        staticText.color = "#FFFFFF";
+        staticText.text = "Hello World!";
+        staticText.renderer = renderText;
+        sprite.addChild(staticText);
 
         var sprite2 = new Sprite();
         sprite2.x = 120;

--- a/demos/app.js
+++ b/demos/app.js
@@ -21,11 +21,10 @@ window.app = (function(){
 
 			canvas = document.getElementById("theCanvas");
 
-			context = canvas.getContext("2d"); // todo only reference context in stage
 			setupCanvasStyles(canvas, document);
 			stage = new Stage(canvas);
 
-			var sprite = new Sprite(context/* TODO remove param, set in stage*/, 10, 10, function(context) {
+			var sprite = new Sprite(10, 10, function(context) {
 				context.drawSquare(0, 0, 100, "#FFF", "#FF0000");
 			},
 			function(x,y){
@@ -36,7 +35,7 @@ window.app = (function(){
 			};
 			stage.addChild(sprite);
 
-			var sprite2 = new Sprite(context /* TODO remove param, set in stage*/, 120, 10, function(context) {
+			var sprite2 = new Sprite(120, 10, function(context) {
 				context.drawSquare(0, 0, 100, "#FFF", "#00FF00");
 				context.drawSquare(10, 10, 20, "#333", "#00FF00");
 				context.drawSquare(20, 20, 20, "#333", "#00FF00");

--- a/demos/app.js
+++ b/demos/app.js
@@ -19,6 +19,10 @@ define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape', 'jcx/StaticText'],function(Stage
         return (x >= this.stageX && x <= this.stageX+this.width) && (y >= this.stageY && y <= this.stageY+this.height);
     }
 
+    function dragObject(e){
+
+    }
+
     function inBoundsOfCircle(x,y){
         var a_squared = Math.pow(this.stageX - x, 2);
         var b_squared = Math.pow(this.stageY - y, 2);
@@ -78,6 +82,17 @@ define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape', 'jcx/StaticText'],function(Stage
         sprite2.name = "nesting sprite";
         sprite2.onclick = logSpriteClick;
 
+        sprite2.onmousedown = function(e){
+            e.target.startDrag();
+        };
+        sprite2.onmouseup = function(e){
+            e.target.stopDrag();
+        };
+        sprite2.onmousemove = function(e){
+            e.target.stageX = e.stageX - 10;
+            e.target.stageY = e.stageY - 10;
+        };
+
         var shape2 = new Shape();
         shape2.name = "yellow square";
         shape2.x = 0;
@@ -128,7 +143,7 @@ define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape', 'jcx/StaticText'],function(Stage
         shape5.height = 20;
         shape5.color = "#00FFFF";
         shape5.renderer = function(context){
-            context.drawCircle(this.stageX, this.stageY,10, "#333",this.color);
+            context.drawCircle(this.stageX, this.stageY,10, "#333", this.color);
         };
         shape5.isInBoundsTester = inBoundsOfCircle;
         shape5.onclick = logSpriteClick;
@@ -142,8 +157,15 @@ define(['jcx/Stage', 'jcx/sprite', 'jcx/Shape', 'jcx/StaticText'],function(Stage
 
         stage.addChild(sprite2);
 
-        stage.draw();
+        loop(stage);
 	}
+    
+    function loop(stage){
+        stage.draw();
+        window.setTimeout(function(){
+            loop(stage);
+        }, 1000/60);
+    }
 
     return init;
 });

--- a/demos/app.js
+++ b/demos/app.js
@@ -1,10 +1,4 @@
-define(['jcx/Stage', 'jcx/sprite'],function(Stage, Sprite){
-	function testSquare(context) {
-		jcx.drawSquare(context, 10, 10, 100, "#FFF");
-		jcx.drawSquare(context, 120, 10, 100, "#FFF","#EEE");
-		jcx.drawSquare(context, 230, 10, 100, "#FF3333","#FFCCCC");
-	}
-
+define(['jcx', 'jcx/Stage', 'jcx/sprite'],function(JCX, Stage, Sprite){
 	function setupCanvasStyles(canvas, document) {
 		canvas.width = document.width;
 		canvas.height = document.height;
@@ -22,7 +16,7 @@ define(['jcx/Stage', 'jcx/sprite'],function(Stage, Sprite){
         setupCanvasStyles(canvas, document);
         stage = new Stage(canvas);
 
-        var sprite = new Sprite(10, 10, function(context) {
+        var sprite = new Sprite(10,10,function(context) {
             context.drawSquare(0, 0, 100, "#FFF", "#FF0000");
         },
         function(x,y){
@@ -35,7 +29,6 @@ define(['jcx/Stage', 'jcx/sprite'],function(Stage, Sprite){
 
         var sprite2 = new Sprite(120, 10, function(context) {
             context.drawSquare(0, 0, 100, "#FFF", "#FFFF00");
-            context.drawSquare(10, 10, 20, "#333", "#FF0000");
             context.drawSquare(20, 20, 20, "#333", "#00FF00");
             context.drawSquare(30, 30, 20, "#333", "#0000FF");
         },
@@ -45,7 +38,22 @@ define(['jcx/Stage', 'jcx/sprite'],function(Stage, Sprite){
         sprite2.onclick = function(e) {
             console.log("Sprite 2 was clicked : " + e.target.x + ", " + e.target.y);
         };
+
+        var sprite3 = new Sprite(10, 10, function(context){
+            context.drawCircle(10,10,10, "#333","#00FFFF");
+        },
+        function(x,y){
+            var a_squared = Math.pow(this.jcx.xOffset + this.x - x, 2);
+            var b_squared = Math.pow(this.jcx.yOffset + this.y - y, 2);
+            var c_squared = a_squared + b_squared;
+            return c_squared < 100;
+        });
+        sprite3.onclick = function(e){
+            console.log("Sprite 3 was clicked : " + e.target.x + ", " + e.target.y);
+        };
         stage.addChild(sprite2);
+
+        sprite2.addChild(sprite3);
 
         stage.draw();
 	}

--- a/demos/index.html
+++ b/demos/index.html
@@ -1,15 +1,7 @@
 	<html>
 	<head>
-		<link rel="stylesheet" type="text/css" href="styles.css" />
-		
-		<script type="text/javascript" src="../src/jcx.js"></script>	
-        <script type="text/javascript" src="../src/jcx/JCXEvent.js"></script>
-        <script type="text/javascript" src="../src/jcx/DisplayObject.js"></script>  
-        <script type="text/javascript" src="../src/jcx/DisplayObjectContainer.js"></script>  
-        <script type="text/javascript" src="../src/jcx/Sprite.js"></script>    
-        <script type="text/javascript" src="../src/jcx/Stage.js"></script>    
-		<script type="text/javascript" src="app.js"></script>
-
+        <link rel="stylesheet" type="text/css" href="styles.css" />
+        <script data-main="main.js" type="text/javascript" src="require.js"></script>
 	</head>
 	<body>
 		<canvas id="theCanvas">Sorry, you can't see the cool stuff here, so get a new browser.</canvas>

--- a/demos/main.js
+++ b/demos/main.js
@@ -1,0 +1,8 @@
+require.config({
+    paths:{
+        jcx: '../src/jcx'
+    },
+});
+require(["app"], function(init){
+    init();
+});

--- a/demos/require.js
+++ b/demos/require.js
@@ -1,0 +1,2053 @@
+/** vim: et:ts=4:sw=4:sts=4
+ * @license RequireJS 2.0.4+ Copyright (c) 2010-2012, The Dojo Foundation All Rights Reserved.
+ * Available via the MIT or new BSD license.
+ * see: http://github.com/jrburke/requirejs for details
+ */
+//Not using strict: uneven strict support in browsers, #392, and causes
+//problems with requirejs.exec()/transpiler plugins that may not be strict.
+/*jslint regexp: true, nomen: true, sloppy: true */
+/*global window, navigator, document, importScripts, jQuery, setTimeout, opera */
+
+var requirejs, require, define;
+(function (global) {
+    var req, s, head, baseElement, dataMain, src,
+        interactiveScript, currentlyAddingScript, mainScript, subPath,
+        version = '2.0.4+',
+        commentRegExp = /(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg,
+        cjsRequireRegExp = /[^.]\s*require\s*\(\s*["']([^'"\s]+)["']\s*\)/g,
+        jsSuffixRegExp = /\.js$/,
+        currDirRegExp = /^\.\//,
+        op = Object.prototype,
+        ostring = op.toString,
+        hasOwn = op.hasOwnProperty,
+        ap = Array.prototype,
+        aps = ap.slice,
+        apsp = ap.splice,
+        isBrowser = !!(typeof window !== 'undefined' && navigator && document),
+        isWebWorker = !isBrowser && typeof importScripts !== 'undefined',
+        //PS3 indicates loaded and complete, but need to wait for complete
+        //specifically. Sequence is 'loading', 'loaded', execution,
+        // then 'complete'. The UA check is unfortunate, but not sure how
+        //to feature test w/o causing perf issues.
+        readyRegExp = isBrowser && navigator.platform === 'PLAYSTATION 3' ?
+                      /^complete$/ : /^(complete|loaded)$/,
+        defContextName = '_',
+        //Oh the tragedy, detecting opera. See the usage of isOpera for reason.
+        isOpera = typeof opera !== 'undefined' && opera.toString() === '[object Opera]',
+        contexts = {},
+        cfg = {},
+        globalDefQueue = [],
+        useInteractive = false;
+
+    function isFunction(it) {
+        return ostring.call(it) === '[object Function]';
+    }
+
+    function isArray(it) {
+        return ostring.call(it) === '[object Array]';
+    }
+
+    /**
+     * Helper function for iterating over an array. If the func returns
+     * a true value, it will break out of the loop.
+     */
+    function each(ary, func) {
+        if (ary) {
+            var i;
+            for (i = 0; i < ary.length; i += 1) {
+                if (ary[i] && func(ary[i], i, ary)) {
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Helper function for iterating over an array backwards. If the func
+     * returns a true value, it will break out of the loop.
+     */
+    function eachReverse(ary, func) {
+        if (ary) {
+            var i;
+            for (i = ary.length - 1; i > -1; i -= 1) {
+                if (ary[i] && func(ary[i], i, ary)) {
+                    break;
+                }
+            }
+        }
+    }
+
+    function hasProp(obj, prop) {
+        return hasOwn.call(obj, prop);
+    }
+
+    /**
+     * Cycles over properties in an object and calls a function for each
+     * property value. If the function returns a truthy value, then the
+     * iteration is stopped.
+     */
+    function eachProp(obj, func) {
+        var prop;
+        for (prop in obj) {
+            if (obj.hasOwnProperty(prop)) {
+                if (func(obj[prop], prop)) {
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Simple function to mix in properties from source into target,
+     * but only if target does not already have a property of the same name.
+     * This is not robust in IE for transferring methods that match
+     * Object.prototype names, but the uses of mixin here seem unlikely to
+     * trigger a problem related to that.
+     */
+    function mixin(target, source, force, deepStringMixin) {
+        if (source) {
+            eachProp(source, function (value, prop) {
+                if (force || !hasProp(target, prop)) {
+                    if (deepStringMixin && typeof value !== 'string') {
+                        if (!target[prop]) {
+                            target[prop] = {};
+                        }
+                        mixin(target[prop], value, force, deepStringMixin);
+                    } else {
+                        target[prop] = value;
+                    }
+                }
+            });
+        }
+        return target;
+    }
+
+    //Similar to Function.prototype.bind, but the 'this' object is specified
+    //first, since it is easier to read/figure out what 'this' will be.
+    function bind(obj, fn) {
+        return function () {
+            return fn.apply(obj, arguments);
+        };
+    }
+
+    function scripts() {
+        return document.getElementsByTagName('script');
+    }
+
+    //Allow getting a global that expressed in
+    //dot notation, like 'a.b.c'.
+    function getGlobal(value) {
+        if (!value) {
+            return value;
+        }
+        var g = global;
+        each(value.split('.'), function (part) {
+            g = g[part];
+        });
+        return g;
+    }
+
+    function makeContextModuleFunc(func, relMap, enableBuildCallback) {
+        return function () {
+            //A version of a require function that passes a moduleName
+            //value for items that may need to
+            //look up paths relative to the moduleName
+            var args = aps.call(arguments, 0), lastArg;
+            if (enableBuildCallback &&
+                    isFunction((lastArg = args[args.length - 1]))) {
+                lastArg.__requireJsBuild = true;
+            }
+            args.push(relMap);
+            return func.apply(null, args);
+        };
+    }
+
+    function addRequireMethods(req, context, relMap) {
+        each([
+            ['toUrl'],
+            ['undef'],
+            ['defined', 'requireDefined'],
+            ['specified', 'requireSpecified']
+        ], function (item) {
+            var prop = item[1] || item[0];
+            req[item[0]] = context ? makeContextModuleFunc(context[prop], relMap) :
+                    //If no context, then use default context. Reference from
+                    //contexts instead of early binding to default context, so
+                    //that during builds, the latest instance of the default
+                    //context with its config gets used.
+                    function () {
+                        var ctx = contexts[defContextName];
+                        return ctx[prop].apply(ctx, arguments);
+                    };
+        });
+    }
+
+    /**
+     * Constructs an error with a pointer to an URL with more information.
+     * @param {String} id the error ID that maps to an ID on a web page.
+     * @param {String} message human readable error.
+     * @param {Error} [err] the original error, if there is one.
+     *
+     * @returns {Error}
+     */
+    function makeError(id, msg, err, requireModules) {
+        var e = new Error(msg + '\nhttp://requirejs.org/docs/errors.html#' + id);
+        e.requireType = id;
+        e.requireModules = requireModules;
+        if (err) {
+            e.originalError = err;
+        }
+        return e;
+    }
+
+    if (typeof define !== 'undefined') {
+        //If a define is already in play via another AMD loader,
+        //do not overwrite.
+        return;
+    }
+
+    if (typeof requirejs !== 'undefined') {
+        if (isFunction(requirejs)) {
+            //Do not overwrite and existing requirejs instance.
+            return;
+        }
+        cfg = requirejs;
+        requirejs = undefined;
+    }
+
+    //Allow for a require config object
+    if (typeof require !== 'undefined' && !isFunction(require)) {
+        //assume it is a config object.
+        cfg = require;
+        require = undefined;
+    }
+
+    function newContext(contextName) {
+        var inCheckLoaded, Module, context, handlers,
+            checkLoadedTimeoutId,
+            config = {
+                waitSeconds: 7,
+                baseUrl: './',
+                paths: {},
+                pkgs: {},
+                shim: {}
+            },
+            registry = {},
+            undefEvents = {},
+            defQueue = [],
+            defined = {},
+            urlFetched = {},
+            requireCounter = 1,
+            unnormalizedCounter = 1,
+            //Used to track the order in which modules
+            //should be executed, by the order they
+            //load. Important for consistent cycle resolution
+            //behavior.
+            waitAry = [];
+
+        /**
+         * Trims the . and .. from an array of path segments.
+         * It will keep a leading path segment if a .. will become
+         * the first path segment, to help with module name lookups,
+         * which act like paths, but can be remapped. But the end result,
+         * all paths that use this function should look normalized.
+         * NOTE: this method MODIFIES the input array.
+         * @param {Array} ary the array of path segments.
+         */
+        function trimDots(ary) {
+            var i, part;
+            for (i = 0; ary[i]; i += 1) {
+                part = ary[i];
+                if (part === '.') {
+                    ary.splice(i, 1);
+                    i -= 1;
+                } else if (part === '..') {
+                    if (i === 1 && (ary[2] === '..' || ary[0] === '..')) {
+                        //End of the line. Keep at least one non-dot
+                        //path segment at the front so it can be mapped
+                        //correctly to disk. Otherwise, there is likely
+                        //no path mapping for a path starting with '..'.
+                        //This can still fail, but catches the most reasonable
+                        //uses of ..
+                        break;
+                    } else if (i > 0) {
+                        ary.splice(i - 1, 2);
+                        i -= 2;
+                    }
+                }
+            }
+        }
+
+        /**
+         * Given a relative module name, like ./something, normalize it to
+         * a real name that can be mapped to a path.
+         * @param {String} name the relative name
+         * @param {String} baseName a real name that the name arg is relative
+         * to.
+         * @param {Boolean} applyMap apply the map config to the value. Should
+         * only be done if this normalization is for a dependency ID.
+         * @returns {String} normalized name
+         */
+        function normalize(name, baseName, applyMap) {
+            var pkgName, pkgConfig, mapValue, nameParts, i, j, nameSegment,
+                foundMap, foundI, foundStarMap, starI,
+                baseParts = baseName && baseName.split('/'),
+                normalizedBaseParts = baseParts,
+                map = config.map,
+                starMap = map && map['*'];
+
+            //Adjust any relative paths.
+            if (name && name.charAt(0) === '.') {
+                //If have a base name, try to normalize against it,
+                //otherwise, assume it is a top-level require that will
+                //be relative to baseUrl in the end.
+                if (baseName) {
+                    if (config.pkgs[baseName]) {
+                        //If the baseName is a package name, then just treat it as one
+                        //name to concat the name with.
+                        normalizedBaseParts = baseParts = [baseName];
+                    } else {
+                        //Convert baseName to array, and lop off the last part,
+                        //so that . matches that 'directory' and not name of the baseName's
+                        //module. For instance, baseName of 'one/two/three', maps to
+                        //'one/two/three.js', but we want the directory, 'one/two' for
+                        //this normalization.
+                        normalizedBaseParts = baseParts.slice(0, baseParts.length - 1);
+                    }
+
+                    name = normalizedBaseParts.concat(name.split('/'));
+                    trimDots(name);
+
+                    //Some use of packages may use a . path to reference the
+                    //'main' module name, so normalize for that.
+                    pkgConfig = config.pkgs[(pkgName = name[0])];
+                    name = name.join('/');
+                    if (pkgConfig && name === pkgName + '/' + pkgConfig.main) {
+                        name = pkgName;
+                    }
+                } else if (name.indexOf('./') === 0) {
+                    // No baseName, so this is ID is resolved relative
+                    // to baseUrl, pull off the leading dot.
+                    name = name.substring(2);
+                }
+            }
+
+            //Apply map config if available.
+            if (applyMap && (baseParts || starMap) && map) {
+                nameParts = name.split('/');
+
+                for (i = nameParts.length; i > 0; i -= 1) {
+                    nameSegment = nameParts.slice(0, i).join('/');
+
+                    if (baseParts) {
+                        //Find the longest baseName segment match in the config.
+                        //So, do joins on the biggest to smallest lengths of baseParts.
+                        for (j = baseParts.length; j > 0; j -= 1) {
+                            mapValue = map[baseParts.slice(0, j).join('/')];
+
+                            //baseName segment has config, find if it has one for
+                            //this name.
+                            if (mapValue) {
+                                mapValue = mapValue[nameSegment];
+                                if (mapValue) {
+                                    //Match, update name to the new value.
+                                    foundMap = mapValue;
+                                    foundI = i;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    if (foundMap) {
+                        break;
+                    }
+
+                    //Check for a star map match, but just hold on to it,
+                    //if there is a shorter segment match later in a matching
+                    //config, then favor over this star map.
+                    if (!foundStarMap && starMap && starMap[nameSegment]) {
+                        foundStarMap = starMap[nameSegment];
+                        starI = i;
+                    }
+                }
+
+                if (!foundMap && foundStarMap) {
+                    foundMap = foundStarMap;
+                    foundI = starI;
+                }
+
+                if (foundMap) {
+                    nameParts.splice(0, foundI, foundMap);
+                    name = nameParts.join('/');
+                }
+            }
+
+            return name;
+        }
+
+        function removeScript(name) {
+            if (isBrowser) {
+                each(scripts(), function (scriptNode) {
+                    if (scriptNode.getAttribute('data-requiremodule') === name &&
+                            scriptNode.getAttribute('data-requirecontext') === context.contextName) {
+                        scriptNode.parentNode.removeChild(scriptNode);
+                        return true;
+                    }
+                });
+            }
+        }
+
+        function hasPathFallback(id) {
+            var pathConfig = config.paths[id];
+            if (pathConfig && isArray(pathConfig) && pathConfig.length > 1) {
+                removeScript(id);
+                //Pop off the first array value, since it failed, and
+                //retry
+                pathConfig.shift();
+                context.undef(id);
+                context.require([id]);
+                return true;
+            }
+        }
+
+        /**
+         * Creates a module mapping that includes plugin prefix, module
+         * name, and path. If parentModuleMap is provided it will
+         * also normalize the name via require.normalize()
+         *
+         * @param {String} name the module name
+         * @param {String} [parentModuleMap] parent module map
+         * for the module name, used to resolve relative names.
+         * @param {Boolean} isNormalized: is the ID already normalized.
+         * This is true if this call is done for a define() module ID.
+         * @param {Boolean} applyMap: apply the map config to the ID.
+         * Should only be true if this map is for a dependency.
+         *
+         * @returns {Object}
+         */
+        function makeModuleMap(name, parentModuleMap, isNormalized, applyMap) {
+            var url, pluginModule, suffix,
+                index = name ? name.indexOf('!') : -1,
+                prefix = null,
+                parentName = parentModuleMap ? parentModuleMap.name : null,
+                originalName = name,
+                isDefine = true,
+                normalizedName = '';
+
+            //If no name, then it means it is a require call, generate an
+            //internal name.
+            if (!name) {
+                isDefine = false;
+                name = '_@r' + (requireCounter += 1);
+            }
+
+            if (index !== -1) {
+                prefix = name.substring(0, index);
+                name = name.substring(index + 1, name.length);
+            }
+
+            if (prefix) {
+                prefix = normalize(prefix, parentName, applyMap);
+                pluginModule = defined[prefix];
+            }
+
+            //Account for relative paths if there is a base name.
+            if (name) {
+                if (prefix) {
+                    if (pluginModule && pluginModule.normalize) {
+                        //Plugin is loaded, use its normalize method.
+                        normalizedName = pluginModule.normalize(name, function (name) {
+                            return normalize(name, parentName, applyMap);
+                        });
+                    } else {
+                        normalizedName = normalize(name, parentName, applyMap);
+                    }
+                } else {
+                    //A regular module.
+                    normalizedName = normalize(name, parentName, applyMap);
+                    url = context.nameToUrl(normalizedName);
+                }
+            }
+
+            //If the id is a plugin id that cannot be determined if it needs
+            //normalization, stamp it with a unique ID so two matching relative
+            //ids that may conflict can be separate.
+            suffix = prefix && !pluginModule && !isNormalized ?
+                     '_unnormalized' + (unnormalizedCounter += 1) :
+                     '';
+
+            return {
+                prefix: prefix,
+                name: normalizedName,
+                parentMap: parentModuleMap,
+                unnormalized: !!suffix,
+                url: url,
+                originalName: originalName,
+                isDefine: isDefine,
+                id: (prefix ?
+                        prefix + '!' + normalizedName :
+                        normalizedName) + suffix
+            };
+        }
+
+        function getModule(depMap) {
+            var id = depMap.id,
+                mod = registry[id];
+
+            if (!mod) {
+                mod = registry[id] = new context.Module(depMap);
+            }
+
+            return mod;
+        }
+
+        function on(depMap, name, fn) {
+            var id = depMap.id,
+                mod = registry[id];
+
+            if (hasProp(defined, id) &&
+                    (!mod || mod.defineEmitComplete)) {
+                if (name === 'defined') {
+                    fn(defined[id]);
+                }
+            } else {
+                getModule(depMap).on(name, fn);
+            }
+        }
+
+        function onError(err, errback) {
+            var ids = err.requireModules,
+                notified = false;
+
+            if (errback) {
+                errback(err);
+            } else {
+                each(ids, function (id) {
+                    var mod = registry[id];
+                    if (mod) {
+                        //Set error on module, so it skips timeout checks.
+                        mod.error = err;
+                        if (mod.events.error) {
+                            notified = true;
+                            mod.emit('error', err);
+                        }
+                    }
+                });
+
+                if (!notified) {
+                    req.onError(err);
+                }
+            }
+        }
+
+        /**
+         * Internal method to transfer globalQueue items to this context's
+         * defQueue.
+         */
+        function takeGlobalQueue() {
+            //Push all the globalDefQueue items into the context's defQueue
+            if (globalDefQueue.length) {
+                //Array splice in the values since the context code has a
+                //local var ref to defQueue, so cannot just reassign the one
+                //on context.
+                apsp.apply(defQueue,
+                           [defQueue.length - 1, 0].concat(globalDefQueue));
+                globalDefQueue = [];
+            }
+        }
+
+        /**
+         * Helper function that creates a require function object to give to
+         * modules that ask for it as a dependency. It needs to be specific
+         * per module because of the implication of path mappings that may
+         * need to be relative to the module name.
+         */
+        function makeRequire(mod, enableBuildCallback, altRequire) {
+            var relMap = mod && mod.map,
+                modRequire = makeContextModuleFunc(altRequire || context.require,
+                                                   relMap,
+                                                   enableBuildCallback);
+
+            addRequireMethods(modRequire, context, relMap);
+            modRequire.isBrowser = isBrowser;
+
+            return modRequire;
+        }
+
+        handlers = {
+            'require': function (mod) {
+                return makeRequire(mod);
+            },
+            'exports': function (mod) {
+                mod.usingExports = true;
+                if (mod.map.isDefine) {
+                    return (mod.exports = defined[mod.map.id] = {});
+                }
+            },
+            'module': function (mod) {
+                return (mod.module = {
+                    id: mod.map.id,
+                    uri: mod.map.url,
+                    config: function () {
+                        return (config.config && config.config[mod.map.id]) || {};
+                    },
+                    exports: defined[mod.map.id]
+                });
+            }
+        };
+
+        function removeWaiting(id) {
+            //Clean up machinery used for waiting modules.
+            delete registry[id];
+
+            each(waitAry, function (mod, i) {
+                if (mod.map.id === id) {
+                    waitAry.splice(i, 1);
+                    if (!mod.defined) {
+                        context.waitCount -= 1;
+                    }
+                    return true;
+                }
+            });
+        }
+
+        function findCycle(mod, traced) {
+            var id = mod.map.id,
+                depArray = mod.depMaps,
+                foundModule;
+
+            //Do not bother with unitialized modules or not yet enabled
+            //modules.
+            if (!mod.inited) {
+                return;
+            }
+
+            //Found the cycle.
+            if (traced[id]) {
+                return mod;
+            }
+
+            traced[id] = true;
+
+            //Trace through the dependencies.
+            each(depArray, function (depMap) {
+                var depId = depMap.id,
+                    depMod = registry[depId];
+
+                if (!depMod) {
+                    return;
+                }
+
+                if (!depMod.inited || !depMod.enabled) {
+                    //Dependency is not inited, so this cannot
+                    //be used to determine a cycle.
+                    foundModule = null;
+                    delete traced[id];
+                    return true;
+                }
+
+                //mixin traced to a new object for each dependency, so that
+                //sibling dependencies in this object to not generate a
+                //false positive match on a cycle. Ideally an Object.create
+                //type of prototype delegation would be used here, but
+                //optimizing for file size vs. execution speed since hopefully
+                //the trees are small for circular dependency scans relative
+                //to the full app perf.
+                return (foundModule = findCycle(depMod, mixin({}, traced)));
+            });
+
+            return foundModule;
+        }
+
+        function forceExec(mod, traced, uninited) {
+            var id = mod.map.id,
+                depArray = mod.depMaps;
+
+            if (!mod.inited || !mod.map.isDefine) {
+                return;
+            }
+
+            if (traced[id]) {
+                return defined[id];
+            }
+
+            traced[id] = mod;
+
+            each(depArray, function (depMap) {
+                var depId = depMap.id,
+                    depMod = registry[depId],
+                    value;
+
+                if (handlers[depId]) {
+                    return;
+                }
+
+                if (depMod) {
+                    if (!depMod.inited || !depMod.enabled) {
+                        //Dependency is not inited,
+                        //so this module cannot be
+                        //given a forced value yet.
+                        uninited[id] = true;
+                        return;
+                    }
+
+                    //Get the value for the current dependency
+                    value = forceExec(depMod, traced, uninited);
+
+                    //Even with forcing it may not be done,
+                    //in particular if the module is waiting
+                    //on a plugin resource.
+                    if (!uninited[depId]) {
+                        mod.defineDepById(depId, value);
+                    }
+                }
+            });
+
+            mod.check(true);
+
+            return defined[id];
+        }
+
+        function modCheck(mod) {
+            mod.check();
+        }
+
+        function checkLoaded() {
+            var map, modId, err, usingPathFallback,
+                waitInterval = config.waitSeconds * 1000,
+                //It is possible to disable the wait interval by using waitSeconds of 0.
+                expired = waitInterval && (context.startTime + waitInterval) < new Date().getTime(),
+                noLoads = [],
+                stillLoading = false,
+                needCycleCheck = true;
+
+            //Do not bother if this call was a result of a cycle break.
+            if (inCheckLoaded) {
+                return;
+            }
+
+            inCheckLoaded = true;
+
+            //Figure out the state of all the modules.
+            eachProp(registry, function (mod) {
+                map = mod.map;
+                modId = map.id;
+
+                //Skip things that are not enabled or in error state.
+                if (!mod.enabled) {
+                    return;
+                }
+
+                if (!mod.error) {
+                    //If the module should be executed, and it has not
+                    //been inited and time is up, remember it.
+                    if (!mod.inited && expired) {
+                        if (hasPathFallback(modId)) {
+                            usingPathFallback = true;
+                            stillLoading = true;
+                        } else {
+                            noLoads.push(modId);
+                            removeScript(modId);
+                        }
+                    } else if (!mod.inited && mod.fetched && map.isDefine) {
+                        stillLoading = true;
+                        if (!map.prefix) {
+                            //No reason to keep looking for unfinished
+                            //loading. If the only stillLoading is a
+                            //plugin resource though, keep going,
+                            //because it may be that a plugin resource
+                            //is waiting on a non-plugin cycle.
+                            return (needCycleCheck = false);
+                        }
+                    }
+                }
+            });
+
+            if (expired && noLoads.length) {
+                //If wait time expired, throw error of unloaded modules.
+                err = makeError('timeout', 'Load timeout for modules: ' + noLoads, null, noLoads);
+                err.contextName = context.contextName;
+                return onError(err);
+            }
+
+            //Not expired, check for a cycle.
+            if (needCycleCheck) {
+
+                each(waitAry, function (mod) {
+                    if (mod.defined) {
+                        return;
+                    }
+
+                    var cycleMod = findCycle(mod, {}),
+                        traced = {};
+
+                    if (cycleMod) {
+                        forceExec(cycleMod, traced, {});
+
+                        //traced modules may have been
+                        //removed from the registry, but
+                        //their listeners still need to
+                        //be called.
+                        eachProp(traced, modCheck);
+                    }
+                });
+
+                //Now that dependencies have
+                //been satisfied, trigger the
+                //completion check that then
+                //notifies listeners.
+                eachProp(registry, modCheck);
+            }
+
+            //If still waiting on loads, and the waiting load is something
+            //other than a plugin resource, or there are still outstanding
+            //scripts, then just try back later.
+            if ((!expired || usingPathFallback) && stillLoading) {
+                //Something is still waiting to load. Wait for it, but only
+                //if a timeout is not already in effect.
+                if ((isBrowser || isWebWorker) && !checkLoadedTimeoutId) {
+                    checkLoadedTimeoutId = setTimeout(function () {
+                        checkLoadedTimeoutId = 0;
+                        checkLoaded();
+                    }, 50);
+                }
+            }
+
+            inCheckLoaded = false;
+        }
+
+        Module = function (map) {
+            this.events = undefEvents[map.id] || {};
+            this.map = map;
+            this.shim = config.shim[map.id];
+            this.depExports = [];
+            this.depMaps = [];
+            this.depMatched = [];
+            this.pluginMaps = {};
+            this.depCount = 0;
+
+            /* this.exports this.factory
+               this.depMaps = [],
+               this.enabled, this.fetched
+            */
+        };
+
+        Module.prototype = {
+            init: function (depMaps, factory, errback, options) {
+                options = options || {};
+
+                //Do not do more inits if already done. Can happen if there
+                //are multiple define calls for the same module. That is not
+                //a normal, common case, but it is also not unexpected.
+                if (this.inited) {
+                    return;
+                }
+
+                this.factory = factory;
+
+                if (errback) {
+                    //Register for errors on this module.
+                    this.on('error', errback);
+                } else if (this.events.error) {
+                    //If no errback already, but there are error listeners
+                    //on this module, set up an errback to pass to the deps.
+                    errback = bind(this, function (err) {
+                        this.emit('error', err);
+                    });
+                }
+
+                //Do a copy of the dependency array, so that
+                //source inputs are not modified. For example
+                //"shim" deps are passed in here directly, and
+                //doing a direct modification of the depMaps array
+                //would affect that config.
+                this.depMaps = depMaps && depMaps.slice(0);
+                this.depMaps.rjsSkipMap = depMaps.rjsSkipMap;
+
+                this.errback = errback;
+
+                //Indicate this module has be initialized
+                this.inited = true;
+
+                this.ignore = options.ignore;
+
+                //Could have option to init this module in enabled mode,
+                //or could have been previously marked as enabled. However,
+                //the dependencies are not known until init is called. So
+                //if enabled previously, now trigger dependencies as enabled.
+                if (options.enabled || this.enabled) {
+                    //Enable this module and dependencies.
+                    //Will call this.check()
+                    this.enable();
+                } else {
+                    this.check();
+                }
+            },
+
+            defineDepById: function (id, depExports) {
+                var i;
+
+                //Find the index for this dependency.
+                each(this.depMaps, function (map, index) {
+                    if (map.id === id) {
+                        i = index;
+                        return true;
+                    }
+                });
+
+                return this.defineDep(i, depExports);
+            },
+
+            defineDep: function (i, depExports) {
+                //Because of cycles, defined callback for a given
+                //export can be called more than once.
+                if (!this.depMatched[i]) {
+                    this.depMatched[i] = true;
+                    this.depCount -= 1;
+                    this.depExports[i] = depExports;
+                }
+            },
+
+            fetch: function () {
+                if (this.fetched) {
+                    return;
+                }
+                this.fetched = true;
+
+                context.startTime = (new Date()).getTime();
+
+                var map = this.map;
+
+                //If the manager is for a plugin managed resource,
+                //ask the plugin to load it now.
+                if (this.shim) {
+                    makeRequire(this, true)(this.shim.deps || [], bind(this, function () {
+                        return map.prefix ? this.callPlugin() : this.load();
+                    }));
+                } else {
+                    //Regular dependency.
+                    return map.prefix ? this.callPlugin() : this.load();
+                }
+            },
+
+            load: function () {
+                var url = this.map.url;
+
+                //Regular dependency.
+                if (!urlFetched[url]) {
+                    urlFetched[url] = true;
+                    context.load(this.map.id, url);
+                }
+            },
+
+            /**
+             * Checks is the module is ready to define itself, and if so,
+             * define it. If the silent argument is true, then it will just
+             * define, but not notify listeners, and not ask for a context-wide
+             * check of all loaded modules. That is useful for cycle breaking.
+             */
+            check: function (silent) {
+                if (!this.enabled || this.enabling) {
+                    return;
+                }
+
+                var err, cjsModule,
+                    id = this.map.id,
+                    depExports = this.depExports,
+                    exports = this.exports,
+                    factory = this.factory;
+
+                if (!this.inited) {
+                    this.fetch();
+                } else if (this.error) {
+                    this.emit('error', this.error);
+                } else if (!this.defining) {
+                    //The factory could trigger another require call
+                    //that would result in checking this module to
+                    //define itself again. If already in the process
+                    //of doing that, skip this work.
+                    this.defining = true;
+
+                    if (this.depCount < 1 && !this.defined) {
+                        if (isFunction(factory)) {
+                            //If there is an error listener, favor passing
+                            //to that instead of throwing an error.
+                            if (this.events.error) {
+                                try {
+                                    exports = context.execCb(id, factory, depExports, exports);
+                                } catch (e) {
+                                    err = e;
+                                }
+                            } else {
+                                exports = context.execCb(id, factory, depExports, exports);
+                            }
+
+                            if (this.map.isDefine) {
+                                //If setting exports via 'module' is in play,
+                                //favor that over return value and exports. After that,
+                                //favor a non-undefined return value over exports use.
+                                cjsModule = this.module;
+                                if (cjsModule &&
+                                        cjsModule.exports !== undefined &&
+                                        //Make sure it is not already the exports value
+                                        cjsModule.exports !== this.exports) {
+                                    exports = cjsModule.exports;
+                                } else if (exports === undefined && this.usingExports) {
+                                    //exports already set the defined value.
+                                    exports = this.exports;
+                                }
+                            }
+
+                            if (err) {
+                                err.requireMap = this.map;
+                                err.requireModules = [this.map.id];
+                                err.requireType = 'define';
+                                return onError((this.error = err));
+                            }
+
+                        } else {
+                            //Just a literal value
+                            exports = factory;
+                        }
+
+                        this.exports = exports;
+
+                        if (this.map.isDefine && !this.ignore) {
+                            defined[id] = exports;
+
+                            if (req.onResourceLoad) {
+                                req.onResourceLoad(context, this.map, this.depMaps);
+                            }
+                        }
+
+                        //Clean up
+                        delete registry[id];
+
+                        this.defined = true;
+                        context.waitCount -= 1;
+                        if (context.waitCount === 0) {
+                            //Clear the wait array used for cycles.
+                            waitAry = [];
+                        }
+                    }
+
+                    //Finished the define stage. Allow calling check again
+                    //to allow define notifications below in the case of a
+                    //cycle.
+                    this.defining = false;
+
+                    if (!silent) {
+                        if (this.defined && !this.defineEmitted) {
+                            this.defineEmitted = true;
+                            this.emit('defined', this.exports);
+                            this.defineEmitComplete = true;
+                        }
+                    }
+                }
+            },
+
+            callPlugin: function () {
+                var map = this.map,
+                    id = map.id,
+                    pluginMap = makeModuleMap(map.prefix, null, false, true);
+
+                on(pluginMap, 'defined', bind(this, function (plugin) {
+                    var load, normalizedMap, normalizedMod,
+                        name = this.map.name,
+                        parentName = this.map.parentMap ? this.map.parentMap.name : null;
+
+                    //If current map is not normalized, wait for that
+                    //normalized name to load instead of continuing.
+                    if (this.map.unnormalized) {
+                        //Normalize the ID if the plugin allows it.
+                        if (plugin.normalize) {
+                            name = plugin.normalize(name, function (name) {
+                                return normalize(name, parentName, true);
+                            }) || '';
+                        }
+
+                        normalizedMap = makeModuleMap(map.prefix + '!' + name,
+                                                      this.map.parentMap,
+                                                      false,
+                                                      true);
+                        on(normalizedMap,
+                            'defined', bind(this, function (value) {
+                                this.init([], function () { return value; }, null, {
+                                    enabled: true,
+                                    ignore: true
+                                });
+                            }));
+                        normalizedMod = registry[normalizedMap.id];
+                        if (normalizedMod) {
+                            if (this.events.error) {
+                                normalizedMod.on('error', bind(this, function (err) {
+                                    this.emit('error', err);
+                                }));
+                            }
+                            normalizedMod.enable();
+                        }
+
+                        return;
+                    }
+
+                    load = bind(this, function (value) {
+                        this.init([], function () { return value; }, null, {
+                            enabled: true
+                        });
+                    });
+
+                    load.error = bind(this, function (err) {
+                        this.inited = true;
+                        this.error = err;
+                        err.requireModules = [id];
+
+                        //Remove temp unnormalized modules for this module,
+                        //since they will never be resolved otherwise now.
+                        eachProp(registry, function (mod) {
+                            if (mod.map.id.indexOf(id + '_unnormalized') === 0) {
+                                removeWaiting(mod.map.id);
+                            }
+                        });
+
+                        onError(err);
+                    });
+
+                    //Allow plugins to load other code without having to know the
+                    //context or how to 'complete' the load.
+                    load.fromText = function (moduleName, text) {
+                        /*jslint evil: true */
+                        var hasInteractive = useInteractive;
+
+                        //Turn off interactive script matching for IE for any define
+                        //calls in the text, then turn it back on at the end.
+                        if (hasInteractive) {
+                            useInteractive = false;
+                        }
+
+                        //Prime the system by creating a module instance for
+                        //it.
+                        getModule(makeModuleMap(moduleName));
+
+                        req.exec(text);
+
+                        if (hasInteractive) {
+                            useInteractive = true;
+                        }
+
+                        //Support anonymous modules.
+                        context.completeLoad(moduleName);
+                    };
+
+                    //Use parentName here since the plugin's name is not reliable,
+                    //could be some weird string with no path that actually wants to
+                    //reference the parentName's path.
+                    plugin.load(map.name, makeRequire(map.parentMap, true, function (deps, cb, er) {
+                        deps.rjsSkipMap = true;
+                        return context.require(deps, cb, er);
+                    }), load, config);
+                }));
+
+                context.enable(pluginMap, this);
+                this.pluginMaps[pluginMap.id] = pluginMap;
+            },
+
+            enable: function () {
+                this.enabled = true;
+
+                if (!this.waitPushed) {
+                    waitAry.push(this);
+                    context.waitCount += 1;
+                    this.waitPushed = true;
+                }
+
+                //Set flag mentioning that the module is enabling,
+                //so that immediate calls to the defined callbacks
+                //for dependencies do not trigger inadvertent load
+                //with the depCount still being zero.
+                this.enabling = true;
+
+                //Enable each dependency
+                each(this.depMaps, bind(this, function (depMap, i) {
+                    var id, mod, handler;
+
+                    if (typeof depMap === 'string') {
+                        //Dependency needs to be converted to a depMap
+                        //and wired up to this module.
+                        depMap = makeModuleMap(depMap,
+                                               (this.map.isDefine ? this.map : this.map.parentMap),
+                                               false,
+                                               !this.depMaps.rjsSkipMap);
+                        this.depMaps[i] = depMap;
+
+                        handler = handlers[depMap.id];
+
+                        if (handler) {
+                            this.depExports[i] = handler(this);
+                            return;
+                        }
+
+                        this.depCount += 1;
+
+                        on(depMap, 'defined', bind(this, function (depExports) {
+                            this.defineDep(i, depExports);
+                            this.check();
+                        }));
+
+                        if (this.errback) {
+                            on(depMap, 'error', this.errback);
+                        }
+                    }
+
+                    id = depMap.id;
+                    mod = registry[id];
+
+                    //Skip special modules like 'require', 'exports', 'module'
+                    //Also, don't call enable if it is already enabled,
+                    //important in circular dependency cases.
+                    if (!handlers[id] && mod && !mod.enabled) {
+                        context.enable(depMap, this);
+                    }
+                }));
+
+                //Enable each plugin that is used in
+                //a dependency
+                eachProp(this.pluginMaps, bind(this, function (pluginMap) {
+                    var mod = registry[pluginMap.id];
+                    if (mod && !mod.enabled) {
+                        context.enable(pluginMap, this);
+                    }
+                }));
+
+                this.enabling = false;
+
+                this.check();
+            },
+
+            on: function (name, cb) {
+                var cbs = this.events[name];
+                if (!cbs) {
+                    cbs = this.events[name] = [];
+                }
+                cbs.push(cb);
+            },
+
+            emit: function (name, evt) {
+                each(this.events[name], function (cb) {
+                    cb(evt);
+                });
+                if (name === 'error') {
+                    //Now that the error handler was triggered, remove
+                    //the listeners, since this broken Module instance
+                    //can stay around for a while in the registry/waitAry.
+                    delete this.events[name];
+                }
+            }
+        };
+
+        function callGetModule(args) {
+            getModule(makeModuleMap(args[0], null, true)).init(args[1], args[2]);
+        }
+
+        function removeListener(node, func, name, ieName) {
+            //Favor detachEvent because of IE9
+            //issue, see attachEvent/addEventListener comment elsewhere
+            //in this file.
+            if (node.detachEvent && !isOpera) {
+                //Probably IE. If not it will throw an error, which will be
+                //useful to know.
+                if (ieName) {
+                    node.detachEvent(ieName, func);
+                }
+            } else {
+                node.removeEventListener(name, func, false);
+            }
+        }
+
+        /**
+         * Given an event from a script node, get the requirejs info from it,
+         * and then removes the event listeners on the node.
+         * @param {Event} evt
+         * @returns {Object}
+         */
+        function getScriptData(evt) {
+            //Using currentTarget instead of target for Firefox 2.0's sake. Not
+            //all old browsers will be supported, but this one was easy enough
+            //to support and still makes sense.
+            var node = evt.currentTarget || evt.srcElement;
+
+            //Remove the listeners once here.
+            removeListener(node, context.onScriptLoad, 'load', 'onreadystatechange');
+            removeListener(node, context.onScriptError, 'error');
+
+            return {
+                node: node,
+                id: node && node.getAttribute('data-requiremodule')
+            };
+        }
+
+        return (context = {
+            config: config,
+            contextName: contextName,
+            registry: registry,
+            defined: defined,
+            urlFetched: urlFetched,
+            waitCount: 0,
+            defQueue: defQueue,
+            Module: Module,
+            makeModuleMap: makeModuleMap,
+
+            /**
+             * Set a configuration for the context.
+             * @param {Object} cfg config object to integrate.
+             */
+            configure: function (cfg) {
+                //Make sure the baseUrl ends in a slash.
+                if (cfg.baseUrl) {
+                    if (cfg.baseUrl.charAt(cfg.baseUrl.length - 1) !== '/') {
+                        cfg.baseUrl += '/';
+                    }
+                }
+
+                //Save off the paths and packages since they require special processing,
+                //they are additive.
+                var pkgs = config.pkgs,
+                    shim = config.shim,
+                    paths = config.paths,
+                    map = config.map;
+
+                //Mix in the config values, favoring the new values over
+                //existing ones in context.config.
+                mixin(config, cfg, true);
+
+                //Merge paths.
+                config.paths = mixin(paths, cfg.paths, true);
+
+                //Merge map
+                if (cfg.map) {
+                    config.map = mixin(map || {}, cfg.map, true, true);
+                }
+
+                //Merge shim
+                if (cfg.shim) {
+                    eachProp(cfg.shim, function (value, id) {
+                        //Normalize the structure
+                        if (isArray(value)) {
+                            value = {
+                                deps: value
+                            };
+                        }
+                        if (value.exports && !value.exports.__buildReady) {
+                            value.exports = context.makeShimExports(value.exports);
+                        }
+                        shim[id] = value;
+                    });
+                    config.shim = shim;
+                }
+
+                //Adjust packages if necessary.
+                if (cfg.packages) {
+                    each(cfg.packages, function (pkgObj) {
+                        var location;
+
+                        pkgObj = typeof pkgObj === 'string' ? { name: pkgObj } : pkgObj;
+                        location = pkgObj.location;
+
+                        //Create a brand new object on pkgs, since currentPackages can
+                        //be passed in again, and config.pkgs is the internal transformed
+                        //state for all package configs.
+                        pkgs[pkgObj.name] = {
+                            name: pkgObj.name,
+                            location: location || pkgObj.name,
+                            //Remove leading dot in main, so main paths are normalized,
+                            //and remove any trailing .js, since different package
+                            //envs have different conventions: some use a module name,
+                            //some use a file name.
+                            main: (pkgObj.main || 'main')
+                                  .replace(currDirRegExp, '')
+                                  .replace(jsSuffixRegExp, '')
+                        };
+                    });
+
+                    //Done with modifications, assing packages back to context config
+                    config.pkgs = pkgs;
+                }
+
+                //If there are any "waiting to execute" modules in the registry,
+                //update the maps for them, since their info, like URLs to load,
+                //may have changed.
+                eachProp(registry, function (mod, id) {
+                    //If module already has init called, since it is too
+                    //late to modify them, and ignore unnormalized ones
+                    //since they are transient.
+                    if (!mod.inited && !mod.map.unnormalized) {
+                        mod.map = makeModuleMap(id);
+                    }
+                });
+
+                //If a deps array or a config callback is specified, then call
+                //require with those args. This is useful when require is defined as a
+                //config object before require.js is loaded.
+                if (cfg.deps || cfg.callback) {
+                    context.require(cfg.deps || [], cfg.callback);
+                }
+            },
+
+            makeShimExports: function (exports) {
+                var func;
+                if (typeof exports === 'string') {
+                    func = function () {
+                        return getGlobal(exports);
+                    };
+                    //Save the exports for use in nodefine checking.
+                    func.exports = exports;
+                    return func;
+                } else {
+                    return function () {
+                        return exports.apply(global, arguments);
+                    };
+                }
+            },
+
+            requireDefined: function (id, relMap) {
+                return hasProp(defined, makeModuleMap(id, relMap, false, true).id);
+            },
+
+            requireSpecified: function (id, relMap) {
+                id = makeModuleMap(id, relMap, false, true).id;
+                return hasProp(defined, id) || hasProp(registry, id);
+            },
+
+            require: function (deps, callback, errback, relMap) {
+                var moduleName, id, map, requireMod, args;
+                if (typeof deps === 'string') {
+                    if (isFunction(callback)) {
+                        //Invalid call
+                        return onError(makeError('requireargs', 'Invalid require call'), errback);
+                    }
+
+                    //Synchronous access to one module. If require.get is
+                    //available (as in the Node adapter), prefer that.
+                    //In this case deps is the moduleName and callback is
+                    //the relMap
+                    if (req.get) {
+                        return req.get(context, deps, callback);
+                    }
+
+                    //Just return the module wanted. In this scenario, the
+                    //second arg (if passed) is just the relMap.
+                    moduleName = deps;
+                    relMap = callback;
+
+                    //Normalize module name, if it contains . or ..
+                    map = makeModuleMap(moduleName, relMap, false, true);
+                    id = map.id;
+
+                    if (!hasProp(defined, id)) {
+                        return onError(makeError('notloaded', 'Module name "' +
+                                    id +
+                                    '" has not been loaded yet for context: ' +
+                                    contextName));
+                    }
+                    return defined[id];
+                }
+
+                //Callback require. Normalize args. if callback or errback is
+                //not a function, it means it is a relMap. Test errback first.
+                if (errback && !isFunction(errback)) {
+                    relMap = errback;
+                    errback = undefined;
+                }
+                if (callback && !isFunction(callback)) {
+                    relMap = callback;
+                    callback = undefined;
+                }
+
+                //Any defined modules in the global queue, intake them now.
+                takeGlobalQueue();
+
+                //Make sure any remaining defQueue items get properly processed.
+                while (defQueue.length) {
+                    args = defQueue.shift();
+                    if (args[0] === null) {
+                        return onError(makeError('mismatch', 'Mismatched anonymous define() module: ' + args[args.length - 1]));
+                    } else {
+                        //args are id, deps, factory. Should be normalized by the
+                        //define() function.
+                        callGetModule(args);
+                    }
+                }
+
+                //Mark all the dependencies as needing to be loaded.
+                requireMod = getModule(makeModuleMap(null, relMap));
+
+                requireMod.init(deps, callback, errback, {
+                    enabled: true
+                });
+
+                checkLoaded();
+
+                return context.require;
+            },
+
+            undef: function (id) {
+                //Bind any waiting define() calls to this context,
+                //fix for #408
+                takeGlobalQueue();
+
+                var map = makeModuleMap(id, null, true),
+                    mod = registry[id];
+
+                delete defined[id];
+                delete urlFetched[map.url];
+                delete undefEvents[id];
+
+                if (mod) {
+                    //Hold on to listeners in case the
+                    //module will be attempted to be reloaded
+                    //using a different config.
+                    if (mod.events.defined) {
+                        undefEvents[id] = mod.events;
+                    }
+
+                    removeWaiting(id);
+                }
+            },
+
+            /**
+             * Called to enable a module if it is still in the registry
+             * awaiting enablement. parent module is passed in for context,
+             * used by the optimizer.
+             */
+            enable: function (depMap, parent) {
+                var mod = registry[depMap.id];
+                if (mod) {
+                    getModule(depMap).enable();
+                }
+            },
+
+            /**
+             * Internal method used by environment adapters to complete a load event.
+             * A load event could be a script load or just a load pass from a synchronous
+             * load call.
+             * @param {String} moduleName the name of the module to potentially complete.
+             */
+            completeLoad: function (moduleName) {
+                var found, args, mod,
+                    shim = config.shim[moduleName] || {},
+                    shExports = shim.exports && shim.exports.exports;
+
+                takeGlobalQueue();
+
+                while (defQueue.length) {
+                    args = defQueue.shift();
+                    if (args[0] === null) {
+                        args[0] = moduleName;
+                        //If already found an anonymous module and bound it
+                        //to this name, then this is some other anon module
+                        //waiting for its completeLoad to fire.
+                        if (found) {
+                            break;
+                        }
+                        found = true;
+                    } else if (args[0] === moduleName) {
+                        //Found matching define call for this script!
+                        found = true;
+                    }
+
+                    callGetModule(args);
+                }
+
+                //Do this after the cycle of callGetModule in case the result
+                //of those calls/init calls changes the registry.
+                mod = registry[moduleName];
+
+                if (!found && !defined[moduleName] && mod && !mod.inited) {
+                    if (config.enforceDefine && (!shExports || !getGlobal(shExports))) {
+                        if (hasPathFallback(moduleName)) {
+                            return;
+                        } else {
+                            return onError(makeError('nodefine',
+                                             'No define call for ' + moduleName,
+                                             null,
+                                             [moduleName]));
+                        }
+                    } else {
+                        //A script that does not call define(), so just simulate
+                        //the call for it.
+                        callGetModule([moduleName, (shim.deps || []), shim.exports]);
+                    }
+                }
+
+                checkLoaded();
+            },
+
+            /**
+             * Converts a module name + .extension into an URL path.
+             * *Requires* the use of a module name. It does not support using
+             * plain URLs like nameToUrl.
+             */
+            toUrl: function (moduleNamePlusExt, relModuleMap) {
+                var index = moduleNamePlusExt.lastIndexOf('.'),
+                    ext = null;
+
+                if (index !== -1) {
+                    ext = moduleNamePlusExt.substring(index, moduleNamePlusExt.length);
+                    moduleNamePlusExt = moduleNamePlusExt.substring(0, index);
+                }
+
+                return context.nameToUrl(normalize(moduleNamePlusExt, relModuleMap && relModuleMap.id, true),
+                                         ext);
+            },
+
+            /**
+             * Converts a module name to a file path. Supports cases where
+             * moduleName may actually be just an URL.
+             * Note that it **does not** call normalize on the moduleName,
+             * it is assumed to have already been normalized. This is an
+             * internal API, not a public one. Use toUrl for the public API.
+             */
+            nameToUrl: function (moduleName, ext) {
+                var paths, pkgs, pkg, pkgPath, syms, i, parentModule, url,
+                    parentPath;
+
+                //If a colon is in the URL, it indicates a protocol is used and it is just
+                //an URL to a file, or if it starts with a slash, contains a query arg (i.e. ?)
+                //or ends with .js, then assume the user meant to use an url and not a module id.
+                //The slash is important for protocol-less URLs as well as full paths.
+                if (req.jsExtRegExp.test(moduleName)) {
+                    //Just a plain path, not module name lookup, so just return it.
+                    //Add extension if it is included. This is a bit wonky, only non-.js things pass
+                    //an extension, this method probably needs to be reworked.
+                    url = moduleName + (ext || '');
+                } else {
+                    //A module that needs to be converted to a path.
+                    paths = config.paths;
+                    pkgs = config.pkgs;
+
+                    syms = moduleName.split('/');
+                    //For each module name segment, see if there is a path
+                    //registered for it. Start with most specific name
+                    //and work up from it.
+                    for (i = syms.length; i > 0; i -= 1) {
+                        parentModule = syms.slice(0, i).join('/');
+                        pkg = pkgs[parentModule];
+                        parentPath = paths[parentModule];
+                        if (parentPath) {
+                            //If an array, it means there are a few choices,
+                            //Choose the one that is desired
+                            if (isArray(parentPath)) {
+                                parentPath = parentPath[0];
+                            }
+                            syms.splice(0, i, parentPath);
+                            break;
+                        } else if (pkg) {
+                            //If module name is just the package name, then looking
+                            //for the main module.
+                            if (moduleName === pkg.name) {
+                                pkgPath = pkg.location + '/' + pkg.main;
+                            } else {
+                                pkgPath = pkg.location;
+                            }
+                            syms.splice(0, i, pkgPath);
+                            break;
+                        }
+                    }
+
+                    //Join the path parts together, then figure out if baseUrl is needed.
+                    url = syms.join('/');
+                    url += (ext || (/\?/.test(url) ? '' : '.js'));
+                    url = (url.charAt(0) === '/' || url.match(/^[\w\+\.\-]+:/) ? '' : config.baseUrl) + url;
+                }
+
+                return config.urlArgs ? url +
+                                        ((url.indexOf('?') === -1 ? '?' : '&') +
+                                         config.urlArgs) : url;
+            },
+
+            //Delegates to req.load. Broken out as a separate function to
+            //allow overriding in the optimizer.
+            load: function (id, url) {
+                req.load(context, id, url);
+            },
+
+            /**
+             * Executes a module callack function. Broken out as a separate function
+             * solely to allow the build system to sequence the files in the built
+             * layer in the right sequence.
+             *
+             * @private
+             */
+            execCb: function (name, callback, args, exports) {
+                return callback.apply(exports, args);
+            },
+
+            /**
+             * callback for script loads, used to check status of loading.
+             *
+             * @param {Event} evt the event from the browser for the script
+             * that was loaded.
+             */
+            onScriptLoad: function (evt) {
+                //Using currentTarget instead of target for Firefox 2.0's sake. Not
+                //all old browsers will be supported, but this one was easy enough
+                //to support and still makes sense.
+                if (evt.type === 'load' ||
+                        (readyRegExp.test((evt.currentTarget || evt.srcElement).readyState))) {
+                    //Reset interactive script so a script node is not held onto for
+                    //to long.
+                    interactiveScript = null;
+
+                    //Pull out the name of the module and the context.
+                    var data = getScriptData(evt);
+                    context.completeLoad(data.id);
+                }
+            },
+
+            /**
+             * Callback for script errors.
+             */
+            onScriptError: function (evt) {
+                var data = getScriptData(evt);
+                if (!hasPathFallback(data.id)) {
+                    return onError(makeError('scripterror', 'Script error', evt, [data.id]));
+                }
+            }
+        });
+    }
+
+    /**
+     * Main entry point.
+     *
+     * If the only argument to require is a string, then the module that
+     * is represented by that string is fetched for the appropriate context.
+     *
+     * If the first argument is an array, then it will be treated as an array
+     * of dependency string names to fetch. An optional function callback can
+     * be specified to execute when all of those dependencies are available.
+     *
+     * Make a local req variable to help Caja compliance (it assumes things
+     * on a require that are not standardized), and to give a short
+     * name for minification/local scope use.
+     */
+    req = requirejs = function (deps, callback, errback, optional) {
+
+        //Find the right context, use default
+        var context, config,
+            contextName = defContextName;
+
+        // Determine if have config object in the call.
+        if (!isArray(deps) && typeof deps !== 'string') {
+            // deps is a config object
+            config = deps;
+            if (isArray(callback)) {
+                // Adjust args if there are dependencies
+                deps = callback;
+                callback = errback;
+                errback = optional;
+            } else {
+                deps = [];
+            }
+        }
+
+        if (config && config.context) {
+            contextName = config.context;
+        }
+
+        context = contexts[contextName];
+        if (!context) {
+            context = contexts[contextName] = req.s.newContext(contextName);
+        }
+
+        if (config) {
+            context.configure(config);
+        }
+
+        return context.require(deps, callback, errback);
+    };
+
+    /**
+     * Support require.config() to make it easier to cooperate with other
+     * AMD loaders on globally agreed names.
+     */
+    req.config = function (config) {
+        return req(config);
+    };
+
+    /**
+     * Export require as a global, but only if it does not already exist.
+     */
+    if (!require) {
+        require = req;
+    }
+
+    req.version = version;
+
+    //Used to filter out dependencies that are already paths.
+    req.jsExtRegExp = /^\/|:|\?|\.js$/;
+    req.isBrowser = isBrowser;
+    s = req.s = {
+        contexts: contexts,
+        newContext: newContext
+    };
+
+    //Create default context.
+    req({});
+
+    //Exports some context-sensitive methods on global require, using
+    //default context if no context specified.
+    addRequireMethods(req);
+
+    if (isBrowser) {
+        head = s.head = document.getElementsByTagName('head')[0];
+        //If BASE tag is in play, using appendChild is a problem for IE6.
+        //When that browser dies, this can be removed. Details in this jQuery bug:
+        //http://dev.jquery.com/ticket/2709
+        baseElement = document.getElementsByTagName('base')[0];
+        if (baseElement) {
+            head = s.head = baseElement.parentNode;
+        }
+    }
+
+    /**
+     * Any errors that require explicitly generates will be passed to this
+     * function. Intercept/override it if you want custom error handling.
+     * @param {Error} err the error object.
+     */
+    req.onError = function (err) {
+        throw err;
+    };
+
+    /**
+     * Does the request to load a module for the browser case.
+     * Make this a separate function to allow other environments
+     * to override it.
+     *
+     * @param {Object} context the require context to find state.
+     * @param {String} moduleName the name of the module.
+     * @param {Object} url the URL to the module.
+     */
+    req.load = function (context, moduleName, url) {
+        var config = (context && context.config) || {},
+            node;
+        if (isBrowser) {
+            //In the browser so use a script tag
+            node = config.xhtml ?
+                    document.createElementNS('http://www.w3.org/1999/xhtml', 'html:script') :
+                    document.createElement('script');
+            node.type = config.scriptType || 'text/javascript';
+            node.charset = 'utf-8';
+            node.async = true;
+
+            node.setAttribute('data-requirecontext', context.contextName);
+            node.setAttribute('data-requiremodule', moduleName);
+
+            //Set up load listener. Test attachEvent first because IE9 has
+            //a subtle issue in its addEventListener and script onload firings
+            //that do not match the behavior of all other browsers with
+            //addEventListener support, which fire the onload event for a
+            //script right after the script execution. See:
+            //https://connect.microsoft.com/IE/feedback/details/648057/script-onload-event-is-not-fired-immediately-after-script-execution
+            //UNFORTUNATELY Opera implements attachEvent but does not follow the script
+            //script execution mode.
+            if (node.attachEvent &&
+                    //Check if node.attachEvent is artificially added by custom script or
+                    //natively supported by browser
+                    //read https://github.com/jrburke/requirejs/issues/187
+                    //if we can NOT find [native code] then it must NOT natively supported.
+                    //in IE8, node.attachEvent does not have toString()
+                    //Note the test for "[native code" with no closing brace, see:
+                    //https://github.com/jrburke/requirejs/issues/273
+                    !(node.attachEvent.toString && node.attachEvent.toString().indexOf('[native code') < 0) &&
+                    !isOpera) {
+                //Probably IE. IE (at least 6-8) do not fire
+                //script onload right after executing the script, so
+                //we cannot tie the anonymous define call to a name.
+                //However, IE reports the script as being in 'interactive'
+                //readyState at the time of the define call.
+                useInteractive = true;
+
+                node.attachEvent('onreadystatechange', context.onScriptLoad);
+                //It would be great to add an error handler here to catch
+                //404s in IE9+. However, onreadystatechange will fire before
+                //the error handler, so that does not help. If addEvenListener
+                //is used, then IE will fire error before load, but we cannot
+                //use that pathway given the connect.microsoft.com issue
+                //mentioned above about not doing the 'script execute,
+                //then fire the script load event listener before execute
+                //next script' that other browsers do.
+                //Best hope: IE10 fixes the issues,
+                //and then destroys all installs of IE 6-9.
+                //node.attachEvent('onerror', context.onScriptError);
+            } else {
+                node.addEventListener('load', context.onScriptLoad, false);
+                node.addEventListener('error', context.onScriptError, false);
+            }
+            node.src = url;
+
+            //For some cache cases in IE 6-8, the script executes before the end
+            //of the appendChild execution, so to tie an anonymous define
+            //call to the module name (which is stored on the node), hold on
+            //to a reference to this node, but clear after the DOM insertion.
+            currentlyAddingScript = node;
+            if (baseElement) {
+                head.insertBefore(node, baseElement);
+            } else {
+                head.appendChild(node);
+            }
+            currentlyAddingScript = null;
+
+            return node;
+        } else if (isWebWorker) {
+            //In a web worker, use importScripts. This is not a very
+            //efficient use of importScripts, importScripts will block until
+            //its script is downloaded and evaluated. However, if web workers
+            //are in play, the expectation that a build has been done so that
+            //only one script needs to be loaded anyway. This may need to be
+            //reevaluated if other use cases become common.
+            importScripts(url);
+
+            //Account for anonymous modules
+            context.completeLoad(moduleName);
+        }
+    };
+
+    function getInteractiveScript() {
+        if (interactiveScript && interactiveScript.readyState === 'interactive') {
+            return interactiveScript;
+        }
+
+        eachReverse(scripts(), function (script) {
+            if (script.readyState === 'interactive') {
+                return (interactiveScript = script);
+            }
+        });
+        return interactiveScript;
+    }
+
+    //Look for a data-main script attribute, which could also adjust the baseUrl.
+    if (isBrowser) {
+        //Figure out baseUrl. Get it from the script tag with require.js in it.
+        eachReverse(scripts(), function (script) {
+            //Set the 'head' where we can append children by
+            //using the script's parent.
+            if (!head) {
+                head = script.parentNode;
+            }
+
+            //Look for a data-main attribute to set main script for the page
+            //to load. If it is there, the path to data main becomes the
+            //baseUrl, if it is not already set.
+            dataMain = script.getAttribute('data-main');
+            if (dataMain) {
+                //Set final baseUrl if there is not already an explicit one.
+                if (!cfg.baseUrl) {
+                    //Pull off the directory of data-main for use as the
+                    //baseUrl.
+                    src = dataMain.split('/');
+                    mainScript = src.pop();
+                    subPath = src.length ? src.join('/')  + '/' : './';
+
+                    cfg.baseUrl = subPath;
+                    dataMain = mainScript;
+                }
+
+                //Strip off any trailing .js since dataMain is now
+                //like a module name.
+                dataMain = dataMain.replace(jsSuffixRegExp, '');
+
+                //Put the data-main script in the files to load.
+                cfg.deps = cfg.deps ? cfg.deps.concat(dataMain) : [dataMain];
+
+                return true;
+            }
+        });
+    }
+
+    /**
+     * The function that handles definitions of modules. Differs from
+     * require() in that a string for the module should be the first argument,
+     * and the function to execute after dependencies are loaded should
+     * return a value to define the module corresponding to the first argument's
+     * name.
+     */
+    define = function (name, deps, callback) {
+        var node, context;
+
+        //Allow for anonymous functions
+        if (typeof name !== 'string') {
+            //Adjust args appropriately
+            callback = deps;
+            deps = name;
+            name = null;
+        }
+
+        //This module may not have dependencies
+        if (!isArray(deps)) {
+            callback = deps;
+            deps = [];
+        }
+
+        //If no name, and callback is a function, then figure out if it a
+        //CommonJS thing with dependencies.
+        if (!deps.length && isFunction(callback)) {
+            //Remove comments from the callback string,
+            //look for require calls, and pull them into the dependencies,
+            //but only if there are function args.
+            if (callback.length) {
+                callback
+                    .toString()
+                    .replace(commentRegExp, '')
+                    .replace(cjsRequireRegExp, function (match, dep) {
+                        deps.push(dep);
+                    });
+
+                //May be a CommonJS thing even without require calls, but still
+                //could use exports, and module. Avoid doing exports and module
+                //work though if it just needs require.
+                //REQUIRES the function to expect the CommonJS variables in the
+                //order listed below.
+                deps = (callback.length === 1 ? ['require'] : ['require', 'exports', 'module']).concat(deps);
+            }
+        }
+
+        //If in IE 6-8 and hit an anonymous define() call, do the interactive
+        //work.
+        if (useInteractive) {
+            node = currentlyAddingScript || getInteractiveScript();
+            if (node) {
+                if (!name) {
+                    name = node.getAttribute('data-requiremodule');
+                }
+                context = contexts[node.getAttribute('data-requirecontext')];
+            }
+        }
+
+        //Always save off evaluating the def call until the script onload handler.
+        //This allows multiple modules to be in a file without prematurely
+        //tracing dependencies, and allows for anonymous module support,
+        //where the module name is not known until the script onload event
+        //occurs. If no context, use the global queue, and get it processed
+        //in the onscript load callback.
+        (context ? context.defQueue : globalDefQueue).push([name, deps, callback]);
+    };
+
+    define.amd = {
+        jQuery: true
+    };
+
+
+    /**
+     * Executes the text. Normally just uses eval, but can be modified
+     * to use a better, environment-specific call. Only used for transpiling
+     * loader plugins, not for plain JS modules.
+     * @param {String} text the text to execute/evaluate.
+     */
+    req.exec = function (text) {
+        /*jslint evil: true */
+        return eval(text);
+    };
+
+    //Set up with config info.
+    req(cfg);
+}(this));

--- a/src/jcx.js
+++ b/src/jcx.js
@@ -1,70 +1,68 @@
-(function() {
+define(function() {
 
-	"use strict";
+    "use strict";
 
-	//
-	// using: http://dev.w3.org/html5/2dcontext/ specification for 2d context
-	//
-	
- 	//define([],function(){
+    //
+    // using: http://dev.w3.org/html5/2dcontext/ specification for 2d context
+    //
+    //require(['jcx/Stage']);
+    
+         // a wrapper for normal html5 canvas context to allow relative coordinate space
+         function JCX(context, x, y) {
 
- 		// a wrapper for normal html5 canvas context to allow relative coordinate space
- 		function JCX(context, x, y) {
+             var _x, _y;
 
- 			var _x, _y;
+             _x = x;
+             _y = y;
 
- 			_x = x;
- 			_y = y;
+             Object.defineProperties(this,
+             {
+                 _innerContext : {
+                     value: context,
+                     writable: false,
+                     configurable: false,
+                     enumerable: false
+                 },
+                 xOffset: {
+                     get: function() { return _x; },
+                     set: function(value) { _x = value; },
+                     configurable: false
+                 },
+                 yOffset: {
+                     get: function() { return _y; },
+                     set: function(value) { _y = value; },
+                     configurable: false
+                 }
+             });
+         }
 
- 			Object.defineProperties(this,
- 			{
- 				_innerContext : {
- 					value: context,
- 					writable: false,
- 					configurable: false,
- 					enumerable: false
- 				},
- 				xOffset: {
- 					get: function() { return _x; },
- 					set: function(value) { _x = value; },
- 					configurable: false
- 				},
- 				yOffset: {
- 					get: function() { return _y; },
- 					set: function(value) { _y = value; },
- 					configurable: false
- 				}
- 			});
- 		}
+         JCX.prototype = {
+             drawRectangle: function(x, y, width, height, color, fillColor) {
+                 if( fillColor ) {
+                     this._innerContext.fillStyle = fillColor;
+                     this._innerContext.fillRect(this.xOffset+x, this.yOffset+y, width, height);
+                 }
 
- 		JCX.prototype = {
- 			drawRectangle: function(x, y, width, height, color, fillColor) {
- 				if( fillColor ) {
- 					this._innerContext.fillStyle = fillColor;
- 					this._innerContext.fillRect(this.xOffset+x, this.yOffset+y, width, height);
- 				} 
+                this._innerContext.strokeStyle = color;
+                 this._innerContext.strokeRect(this.xOffset+x, this.yOffset+y, width, height);
+             },
 
-				this._innerContext.strokeStyle = color;
- 				this._innerContext.strokeRect(this.xOffset+x, this.yOffset+y, width, height);
- 			},
+             drawSquare: function(x, y, size, color, fillColor) {
+                this.drawRectangle(x, y, size, size, color, fillColor);
+             },
 
- 			drawSquare: function(x, y, size, color, fillColor) {
-				this.drawRectangle(x, y, size, size, color, fillColor);
- 			},
+             drawCircle: function(x, y, radius, color, fillColor) {
+                
+                 if( fillColor ) {
+                     this._innerContext.fillStyle = fillColor;
+                     this._innerContext.arc(this.xOffset+x, this.yOffset+y, radius, 0, 360);
+                     this._innerContext.fill();
+                 }
 
- 			drawCircle: function(x, y, radius, color, fillColor) {
-				
- 				if( fillColor ) {
- 					this._innerContext.fillStyle = fillColor;
- 					this._innerContext.arc(this.xOffset+x, this.yOffset+y, radius, 0, 360);
- 					this._innerContext.fill();
- 				}
+                this._innerContext.strokeStyle = color;
+                 this._innerContext.stroke();
+             }
 
-				this._innerContext.strokeStyle = color;
- 				this._innerContext.stroke();
- 			}
-
- 		};
-
- 		window.JCX = JCX;
-})();
+         };
+    return JCX;
+});

--- a/src/jcx.js
+++ b/src/jcx.js
@@ -5,7 +5,6 @@ define(function() {
     //
     // using: http://dev.w3.org/html5/2dcontext/ specification for 2d context
     //
-    //require(['jcx/Stage']);
     
          // a wrapper for normal html5 canvas context to allow relative coordinate space
          function JCX(context, x, y) {

--- a/src/jcx.js
+++ b/src/jcx.js
@@ -2,66 +2,47 @@ define(function() {
 
     "use strict";
 
-    //
-    // using: http://dev.w3.org/html5/2dcontext/ specification for 2d context
-    //
-    
-         // a wrapper for normal html5 canvas context to allow relative coordinate space
-         function JCX(context, x, y) {
+     // a wrapper for normal html5 canvas context
+     function JCX(context) {
 
-             var _x, _y;
-
-             _x = x;
-             _y = y;
-
-             Object.defineProperties(this,
-             {
-                 _innerContext : {
-                     value: context,
-                     writable: false,
-                     configurable: false,
-                     enumerable: false
-                 },
-                 xOffset: {
-                     get: function() { return _x; },
-                     set: function(value) { _x = value; },
-                     configurable: false
-                 },
-                 yOffset: {
-                     get: function() { return _y; },
-                     set: function(value) { _y = value; },
-                     configurable: false
-                 }
-             });
-         }
-
-         JCX.prototype = {
-             drawRectangle: function(x, y, width, height, color, fillColor) {
-                 if( fillColor ) {
-                     this._innerContext.fillStyle = fillColor;
-                     this._innerContext.fillRect(this.xOffset+x, this.yOffset+y, width, height);
-                 }
-
-                this._innerContext.strokeStyle = color;
-                 this._innerContext.strokeRect(this.xOffset+x, this.yOffset+y, width, height);
+         Object.defineProperties(this,
+         {
+             _innerContext : {
+                 value: context,
+                 writable: false,
+                 configurable: false,
+                 enumerable: false
              },
+         });
+     }
 
-             drawSquare: function(x, y, size, color, fillColor) {
-                this.drawRectangle(x, y, size, size, color, fillColor);
-             },
+    JCX.prototype = {
+        drawRectangle: function(x, y, width, height, color, fillColor) {
+            if( fillColor ) {
+                this._innerContext.fillStyle = fillColor;
+                this._innerContext.fillRect(x, y, width, height);
+            }
 
-             drawCircle: function(x, y, radius, color, fillColor) {
-                
-                 if( fillColor ) {
-                     this._innerContext.fillStyle = fillColor;
-                     this._innerContext.arc(this.xOffset+x, this.yOffset+y, radius, 0, 360);
-                     this._innerContext.fill();
-                 }
+            this._innerContext.strokeStyle = color;
+            this._innerContext.strokeRect(x, y, width, height);
+        },
 
-                this._innerContext.strokeStyle = color;
-                 this._innerContext.stroke();
-             }
+        drawSquare: function(x, y, size, color, fillColor) {
+            this.drawRectangle(x, y, size, size, color, fillColor);
+        },
 
-         };
+        drawCircle: function(x, y, radius, color, fillColor) {
+            
+            if( fillColor ) {
+                this._innerContext.fillStyle = fillColor;
+                this._innerContext.arc(x, y, radius, 0, 360);
+                this._innerContext.fill();
+            }
+
+            this._innerContext.strokeStyle = color;
+            this._innerContext.stroke();
+        }
+
+    };
     return JCX;
 });

--- a/src/jcx.js
+++ b/src/jcx.js
@@ -32,6 +32,7 @@ define(function() {
         },
         drawCircle: function(x, y, radius, color, fillColor) {
             
+            this._innerContext.beginPath();
             if( fillColor ) {
                 this._innerContext.fillStyle = fillColor;
                 this._innerContext.arc(x, y, radius, 0, 360);
@@ -40,6 +41,7 @@ define(function() {
 
             this._innerContext.strokeStyle = color;
             this._innerContext.stroke();
+            this._innerContext.closePath();
         },
         drawText: function(x, y, text, color, fillColor){
             //y is the bottom (baseline?) of the text by default
@@ -50,6 +52,9 @@ define(function() {
             }
             this._innerContext.strokeStyle = color;
             this._innerContext.strokeText(text,x,y);
+        },
+        clearRect: function(x, y, width, height){
+            this._innerContext.clearRect(x,y,width,height);
         }
     };
     return JCX;

--- a/src/jcx.js
+++ b/src/jcx.js
@@ -42,12 +42,14 @@ define(function() {
             this._innerContext.stroke();
         },
         drawText: function(x, y, text, color, fillColor){
+            //y is the bottom (baseline?) of the text by default
+            this._innerContext.font = "900 14px/2 Consolas";
             if(fillColor){
                 this._innerContext.fillStyle = fillColor;
                 this._innerContext.fillText(text, x, y);
             }
             this._innerContext.strokeStyle = color;
-            this._innerContext.stroke();
+            this._innerContext.strokeText(text,x,y);
         }
     };
     return JCX;

--- a/src/jcx.js
+++ b/src/jcx.js
@@ -30,7 +30,6 @@ define(function() {
         drawSquare: function(x, y, size, color, fillColor) {
             this.drawRectangle(x, y, size, size, color, fillColor);
         },
-
         drawCircle: function(x, y, radius, color, fillColor) {
             
             if( fillColor ) {
@@ -41,8 +40,15 @@ define(function() {
 
             this._innerContext.strokeStyle = color;
             this._innerContext.stroke();
+        },
+        drawText: function(x, y, text, color, fillColor){
+            if(fillColor){
+                this._innerContext.fillStyle = fillColor;
+                this._innerContext.fillText(text, x, y);
+            }
+            this._innerContext.strokeStyle = color;
+            this._innerContext.stroke();
         }
-
     };
     return JCX;
 });

--- a/src/jcx/DisplayObject.js
+++ b/src/jcx/DisplayObject.js
@@ -1,75 +1,254 @@
 (function(){
 
-	"use strict";
+    "use strict";
 
-	// using jcx
-	// using jcx/JCXEvent
+    // using jcx
+    // using jcx/JCXEvent
+    // using jcx/EventDispatcher
 
-	function DisplayObject(x, y) {
-		var _x, _y;
+    function DisplayObject(x, y) {
+        var _x, _y,
+            _scaleX, _scaleY,
+            _stage, _rotation,
+            _opaqueBackground,
+            _mask, _blendShader,
+            _visible;
 
-		if( typeof(x) != "number" ) {
-			throw new Error("x must be a number");
-		}
+        if( typeof(x) !== "number" ) {
+            throw new Error("x must be a number");
+        }
 
-		if( typeof(y) != "number" ) {
-			throw new Error("y must be a number");
-		}
+        if( typeof(y) !== "number" ) {
+            throw new Error("y must be a number");
+        }
 
-		_x = x;
-		_y = y;
+        _x = x;
+        _y = y;
+        _scaleX = 1;
+        _scaleY = 1;
+        _rotation = 0;
+        _opaqueBackground = null;
+        _blendShader = null;
 
-		Object.defineProperties(this,
-		{
-			jcx: {
-				value: null,
-				writable: true,
-				configurable: false,
-				enumerable: false
-			},
-			x: {
-				get: function() { return _x; },
-				set: function(value) {
-					_x = value;
-					this.draw();
-				},
-				configurable: false,
-				enumerable: false
-			},
-			y: {
-				get: function() { return _y; },
-				set: function(value) { 
-					_y = value; 
-					this.draw();
-				},
-				configurable: false,
-				enumerable: false
-			}
-		});
+        Object.defineProperties(this,
+        {
+            jcx: {
+                value: null,
+                writable: true,
+                configurable: false,
+                enumerable: false
+            },
+            alpha: {
+                value: 1.0,
+                writable: true,
+                configurable: false,
+                enumerable: true
+            },
+            blendMode:{
+                value:"",
+                writable: true,
+                configurable: false,
+                enumerable:true
+            },
+            blendShader: {
+                set: function(value){
+                    _blendShader = value;
+                    this.draw();
+                },
+                configurable: false,
+                enumerable: true
+            },
+            cacheAsBitmap: {
+                value: false,
+                writable: true,
+                configurable: false,
+                enumerable: true
+            },
+            cacheAsBitmapMatrix: {
+                value: null,
+                writable: true,
+                configurable: false,
+                enumerable: true
+            },
+            filters: {
+                value: null,
+                writable: true,
+                configurable: false,
+                enumerable: true
+            },
+            height: {
+                value: null,
+                writable: true,
+                configurable: false,
+                enumerable: true
+            },
+            loaderInfo: {
+                value: null,
+                writable: false,
+                configurable: false,
+                enumerable: false
+            },
+            mask: {
+                get: function() { return _mask; },
+                set: function(value){
+                    _mask = value;
+                    this.draw();
+                },
+                configurable: false,
+                enumerable: true
+            },
+            mouseX: {
+                value: null,
+                writable: false,
+                configurable: false,
+                enumerable: false
+            },
+            mouseY: {
+                value: null,
+                writable: false,
+                configurable: false,
+                enumerable: false
+            },
+            name: {
+                value: "",
+                writable: true,
+                configurable: false,
+                enumerable: true
+            },
+            opaqueBackground: {
+                get: function() { return _opaqueBackground; },
+                set: function(value) {
+                    _opaqueBackground = value;
+                    this.draw();
+                },
+                configurable:false,
+                enumerable: true
+            },
+            parentDisplayObjectContainer: {
+                value: null,
+                writable:false,
+                configurable:false,
+                enumerable:false
+            },
+            root: {
+                value: null,
+                writable: false,
+                configurable: false,
+                enumerable: false
+            },
+            rotation: {
+                set: function(value) {
+                    _rotation = value;
+                    this.draw();
+                },
+                configurable: false,
+                enumerable: true
+            },
+            scaleX: {
+                get: function() { return _scaleX; },
+                set: function(value) {
+                    _scaleX = value;
+                    this.draw();
+                },
+                configurable: false,
+                enumerable: true
+
+            },
+            scaleY: {
+                get: function() { return _scaleY; },
+                set: function(value){
+                    _scaleY = value;
+                    this.draw();
+                },
+                configurable: false,
+                enumerable: true
+            },
+            stage: {
+                value: null,
+                writable: false,
+                configurable: false,
+                enumerable: false
+            },
+            visible: {
+                get: function() { return _visible; },
+                set: function(value){
+                    _visible = value;
+                    this.draw();
+                },
+                configurable: false,
+                enumerable: true
+            },
+            width: {
+                value: null,
+                writable:true,
+                configurable: false,
+                enumerable: true
+            },
+            x: {
+                get: function() { return _x; },
+                set: function(value) {
+                    _x = value;
+                    this.draw();
+                },
+                configurable: false,
+                enumerable: true
+            },
+            y: {
+                get: function() { return _y; },
+                set: function(value) {
+                    _y = value;
+                    this.draw();
+                },
+                configurable: false,
+                enumerable: true
+            }
+        });
+    }
+
+    DisplayObject.prototype = new EventDispatcher();
+
+    DisplayObject.prototype._isInBounds = function(x, y) {
+        
+        // test to see if point is inbounds
+
+        return false;
+    };
+    DisplayObject.prototype.draw = function() {
+        // perform drawing logic
+    };
+    DisplayObject.prototype.notifyClick = function(e) {
+        if( this._isInBounds(e.x, e.y) ) {
+            this.onclick(new JCXEvent("click", this));
+        }
+    };
+    DisplayObject.prototype.onclick = function(e) {
+        // do nothing
+    };
+
+    //PUBLIC METHODS
+    //the 'targetCoordinateSpace' parameter should be a DispayObjectContainer
+    DisplayObject.prototype.getBounds = function(targetCoordinateSpace){
+
+    };
+    //the 'targetCoordinateSpace' parameter should be a DisplayObjectContainer
+    DisplayObject.prototype.getRect = function(targetCoordinateSpace){
+        
+    };
+    DisplayObject.prototype.globalToLocal = function(point){
+        
+    };
+    //the 'obj' parameter should be another DisplayObject
+    DisplayObject.prototype.hitTestObject = function(obj){
+
+    };
+    //the 'shapeFlag' argument defaults to false and determines whether to check pixels (true) or just the bounding box (false)
+    DisplayObject.prototype.hitTestPoint = function(x, y, shapeFlag){
+        
+    };
+    DisplayObject.prototype.localToGlobal = function(point){
+
+    };
 
 
-	}
-
-	DisplayObject.prototype = {
-		_isInBounds: function(x, y) {
-			
-			// test to see if point is inbounds
-
-			return false;
-		},
-		draw: function() {
-			// perform drawing logic
-		},
-		notifyClick: function(e) {
-			if( this._isInBounds(e.x, e.y) ) {
-				this.onclick(new JCXEvent("click", this));
-			}
-		},
-		onclick: function(e) {
-			// do nothing
-		}
-	};
-
-
-	window.DisplayObject = DisplayObject;
+    window.DisplayObject = DisplayObject;
 }());

--- a/src/jcx/DisplayObject.js
+++ b/src/jcx/DisplayObject.js
@@ -8,8 +8,6 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
         var _x, _y,
             _scaleX, _scaleY,
             _stage, _rotation,
-            _opaqueBackground,
-            _mask, _blendShader,
             _visible, _onclick;
 
         _x = 0;
@@ -17,8 +15,8 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
         _scaleX = 1;
         _scaleY = 1;
         _rotation = 0;
-        _opaqueBackground = null;
-        _blendShader = null;
+
+        var _stageLocked = false;
 
         Object.defineProperties(this,
         {
@@ -27,26 +25,6 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
                 writable: true,
                 configurable: false,
                 enumerable: false
-            },
-            alpha: {
-                value: 1.0,
-                writable: true,
-                configurable: false,
-                enumerable: true
-            },
-            blendMode:{
-                value:"",
-                writable: true,
-                configurable: false,
-                enumerable:true
-            },
-            blendShader: {
-                set: function(value){
-                    _blendShader = value;
-                    this.draw();
-                },
-                configurable: false,
-                enumerable: true
             },
             cacheAsBitmap: {
                 value: false,
@@ -60,30 +38,9 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
                 configurable: false,
                 enumerable: true
             },
-            filters: {
-                value: null,
-                writable: true,
-                configurable: false,
-                enumerable: true
-            },
             height: {
                 value: null,
                 writable: true,
-                configurable: false,
-                enumerable: true
-            },
-            loaderInfo: {
-                value: null,
-                writable: false,
-                configurable: false,
-                enumerable: false
-            },
-            mask: {
-                get: function() { return _mask; },
-                set: function(value){
-                    _mask = value;
-                    this.draw();
-                },
                 configurable: false,
                 enumerable: true
             },
@@ -104,27 +61,6 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
                 writable: true,
                 configurable: false,
                 enumerable: true
-            },
-            opaqueBackground: {
-                get: function() { return _opaqueBackground; },
-                set: function(value) {
-                    _opaqueBackground = value;
-                    this.draw();
-                },
-                configurable:false,
-                enumerable: true
-            },
-            parentDisplayObjectContainer: {
-                value: null,
-                writable:false,
-                configurable:false,
-                enumerable:false
-            },
-            root: {
-                value: null,
-                writable: false,
-                configurable: false,
-                enumerable: false
             },
             rotation: {
                 set: function(value) {
@@ -153,8 +89,13 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
                 enumerable: true
             },
             stage: {
-                value: null,
-                writable: false,
+                get: function() { return _stage; },
+                set: function(value){
+                    if(!_stageLocked){
+                        _stage = value;
+                    }
+                    _stageLocked = true;
+                },
                 configurable: false,
                 enumerable: false
             },
@@ -162,7 +103,6 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
                 get: function() { return _visible; },
                 set: function(value){
                     _visible = value;
-                    this.draw();
                 },
                 configurable: false,
                 enumerable: true
@@ -177,7 +117,6 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
                 get: function() { return _x; },
                 set: function(value) {
                     _x = value;
-                    //this.draw();
                 },
                 configurable: false,
                 enumerable: true
@@ -186,7 +125,6 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
                 get: function() { return _y; },
                 set: function(value) {
                     _y = value;
-                    //this.draw();
                 },
                 configurable: false,
                 enumerable: true
@@ -208,18 +146,26 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
 
     DisplayObject.prototype = new EventDispatcher();
 
-    DisplayObject.prototype._isInBounds = function(x, y) {
-        
-        // test to see if point is inbounds
+    //Protected properties
+    Object.defineProperties(DisplayObject.prototype, {
+        parentContainer: {
+            value: null,
+            writable:false,
+            configurable:false,
+            enumerable:false
+        },
+    });
 
+    DisplayObject.prototype._isInBounds = function(x, y) {
+        // test to see if point is inbounds
         return false;
     };
     DisplayObject.prototype.draw = function() {
         // perform drawing logic
     };
     DisplayObject.prototype.notifyClick = function(e) {
-        if( this._isInBounds(e.x, e.y) ) {
-            this.dispatchEvent(new MouseEvent(MouseEvent.CLICK, null, null, e.x, e.y));
+        if( this.hitTestPoint(e.stageX, e.stageY) ) {
+            this.dispatchEvent(new MouseEvent(MouseEvent.CLICK, null, null, e.stageX, e.stageY));
         }
     };
 
@@ -235,16 +181,12 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
     DisplayObject.prototype.globalToLocal = function(point){
         
     };
-    //the 'obj' parameter should be another DisplayObject
-    DisplayObject.prototype.hitTestObject = function(obj){
-
-    };
     //the 'shapeFlag' argument defaults to false and determines whether to check pixels (true) or just the bounding box (false)
     DisplayObject.prototype.hitTestPoint = function(x, y, shapeFlag){
-        
+        return this._isInBounds(x, y);
     };
     DisplayObject.prototype.localToGlobal = function(point){
-
+        
     };
     return DisplayObject;
 });

--- a/src/jcx/DisplayObject.js
+++ b/src/jcx/DisplayObject.js
@@ -6,9 +6,12 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
         var _x, _y,
             _scaleX, _scaleY,
             _stage, _rotation,
-            _visible, _onclick,
-            _stageX, _stageY,
-            _context;
+            _visible, _stageX,
+            _stageY, _context;
+
+        var _onclick, _onmousedown,
+            _onmouseup, _onmousemove,
+            _ondoubleclick;
 
         _x = 0;
         _y = 0;
@@ -71,23 +74,21 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
             },
             stageX: {
                 get: function(){
-                    if(_stageX == null || _stageX == undefined){
-                        _stageX = this.x + this.parentContainer.stageX;
-                    }
-                    return _stageX;
+                    return this.x + this.parentContainer.stageX;
                 },
-                set: function(value){_stageX=value;},
+                set: function(value){
+                     this.x = value - this.parentContainer.stageX;
+                },
                 configurable:true,
                 enumerable:true
             },
             stageY: {
                 get: function(){
-                    if(_stageY == null || _stageY == undefined){
-                        _stageY = this.y + this.parentContainer.stageY;
-                    }
-                    return _stageY;
+                    return this.y + this.parentContainer.stageY;
                 },
-                set: function(value){_stageY=value;},
+                set: function(value){
+                    this.y = value - this.parentContainer.stageY;
+                },
                 configurable:true,
                 enumerable:true
             },
@@ -164,7 +165,37 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
                 },
                 configurable:false,
                 enumerable:false
-            }
+            },
+            onmousedown: {
+                get: function(){ return _onmousedown; },
+                set: function(value){
+                    this.removeEventListener(MouseEvent.MOUSE_DOWN);
+                    _onmousedown=value;
+                    this.addEventListener(MouseEvent.MOUSE_DOWN, _onmousedown);
+                },
+                configurable:false,
+                enumerable:false
+            },
+            onmouseup: {
+                get: function(){ return _onmouseup; },
+                set: function(value){
+                    this.removeEventListener(MouseEvent.MOUSE_UP);
+                    _onmouseup=value;
+                    this.addEventListener(MouseEvent.MOUSE_UP, _onmouseup);
+                },
+                configurable:false,
+                enumerable:false
+            },
+            onmousemove: {
+                get: function(){ return _onmousemove; },
+                set: function(value){
+                    this.removeEventListener(MouseEvent.MOUSE_MOVE);
+                    _onmousemove=value;
+                    this.addEventListener(MouseEvent.MOUSE_MOVE, _onmousemove);
+                },
+                configurable:false,
+                enumerable:false
+            },
         });
 
         EventDispatcher.call(this);
@@ -193,7 +224,21 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
             this.dispatchEvent(new MouseEvent(MouseEvent.CLICK, null, null, e.stageX, e.stageY));
         }
     };
-
+    DisplayObject.prototype.notifyMouseDown = function(e) {
+        if( this.hitTestPoint(e.stageX, e.stageY) ) {
+            this.dispatchEvent(new MouseEvent(MouseEvent.MOUSE_DOWN, null, null, e.stageX, e.stageY));
+        }
+    };
+    DisplayObject.prototype.notifyMouseUp = function(e) {
+        if( this.hitTestPoint(e.stageX, e.stageY) ) {
+            this.dispatchEvent(new MouseEvent(MouseEvent.MOUSE_UP, null, null, e.stageX, e.stageY));
+        }
+    };
+    DisplayObject.prototype.notifyMouseMove = function(e) {
+        if( this.isBeingDragged ) {
+            this.dispatchEvent(new MouseEvent(MouseEvent.MOUSE_MOVE, null, null, e.stageX, e.stageY));
+        }
+    };
     //PUBLIC METHODS
     //the 'targetCoordinateSpace' parameter should be a DispayObjectContainer
     DisplayObject.prototype.getBounds = function(targetCoordinateSpace){

--- a/src/jcx/DisplayObject.js
+++ b/src/jcx/DisplayObject.js
@@ -1,10 +1,10 @@
-define(['jcx/EventDispatcher', 'jcx/JCXEvent'], function(EventDispatcher, JCXEvent){
+define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, MouseEvent){
 
     "use strict";
 
     // using jcx
     
-    function DisplayObject(x, y) {
+    function DisplayObject() {
         var _x, _y,
             _scaleX, _scaleY,
             _stage, _rotation,
@@ -12,16 +12,8 @@ define(['jcx/EventDispatcher', 'jcx/JCXEvent'], function(EventDispatcher, JCXEve
             _mask, _blendShader,
             _visible, _onclick;
 
-        if( typeof(x) !== "number" ) {
-            throw new Error("x must be a number");
-        }
-
-        if( typeof(y) !== "number" ) {
-            throw new Error("y must be a number");
-        }
-
-        _x = x;
-        _y = y;
+        _x = 0;
+        _y = 0;
         _scaleX = 1;
         _scaleY = 1;
         _rotation = 0;
@@ -185,7 +177,7 @@ define(['jcx/EventDispatcher', 'jcx/JCXEvent'], function(EventDispatcher, JCXEve
                 get: function() { return _x; },
                 set: function(value) {
                     _x = value;
-                    this.draw();
+                    //this.draw();
                 },
                 configurable: false,
                 enumerable: true
@@ -194,7 +186,7 @@ define(['jcx/EventDispatcher', 'jcx/JCXEvent'], function(EventDispatcher, JCXEve
                 get: function() { return _y; },
                 set: function(value) {
                     _y = value;
-                    this.draw();
+                    //this.draw();
                 },
                 configurable: false,
                 enumerable: true
@@ -202,9 +194,9 @@ define(['jcx/EventDispatcher', 'jcx/JCXEvent'], function(EventDispatcher, JCXEve
             onclick: {
                 get: function(){ return _onclick; },
                 set: function(value){
-                    this.removeEventListener("click");
+                    this.removeEventListener(MouseEvent.CLICK);
                     _onclick=value;
-                    this.addEventListener("click", _onclick);
+                    this.addEventListener(MouseEvent.CLICK, _onclick);
                 },
                 configurable:false,
                 enumerable:false
@@ -227,7 +219,7 @@ define(['jcx/EventDispatcher', 'jcx/JCXEvent'], function(EventDispatcher, JCXEve
     };
     DisplayObject.prototype.notifyClick = function(e) {
         if( this._isInBounds(e.x, e.y) ) {
-            this.dispatchEvent(new JCXEvent("click"));
+            this.dispatchEvent(new MouseEvent(MouseEvent.CLICK, null, null, e.x, e.y));
         }
     };
 

--- a/src/jcx/DisplayObject.js
+++ b/src/jcx/DisplayObject.js
@@ -1,11 +1,9 @@
-(function(){
+define(['jcx/EventDispatcher', 'jcx/JCXEvent'], function(EventDispatcher, JCXEvent){
 
     "use strict";
 
     // using jcx
-    // using jcx/JCXEvent
-    // using jcx/EventDispatcher
-
+    
     function DisplayObject(x, y) {
         var _x, _y,
             _scaleX, _scaleY,
@@ -152,7 +150,6 @@
                 },
                 configurable: false,
                 enumerable: true
-
             },
             scaleY: {
                 get: function() { return _scaleY; },
@@ -203,6 +200,8 @@
                 enumerable: true
             }
         });
+
+        EventDispatcher.call(this);
     }
 
     DisplayObject.prototype = new EventDispatcher();
@@ -248,7 +247,5 @@
     DisplayObject.prototype.localToGlobal = function(point){
 
     };
-
-
-    window.DisplayObject = DisplayObject;
-}());
+    return DisplayObject;
+});

--- a/src/jcx/DisplayObject.js
+++ b/src/jcx/DisplayObject.js
@@ -10,7 +10,7 @@ define(['jcx/EventDispatcher', 'jcx/JCXEvent'], function(EventDispatcher, JCXEve
             _stage, _rotation,
             _opaqueBackground,
             _mask, _blendShader,
-            _visible;
+            _visible, _onclick;
 
         if( typeof(x) !== "number" ) {
             throw new Error("x must be a number");
@@ -198,6 +198,16 @@ define(['jcx/EventDispatcher', 'jcx/JCXEvent'], function(EventDispatcher, JCXEve
                 },
                 configurable: false,
                 enumerable: true
+            },
+            onclick: {
+                get: function(){ return _onclick; },
+                set: function(value){
+                    this.removeEventListener("click");
+                    _onclick=value;
+                    this.addEventListener("click", _onclick);
+                },
+                configurable:false,
+                enumerable:false
             }
         });
 
@@ -217,11 +227,8 @@ define(['jcx/EventDispatcher', 'jcx/JCXEvent'], function(EventDispatcher, JCXEve
     };
     DisplayObject.prototype.notifyClick = function(e) {
         if( this._isInBounds(e.x, e.y) ) {
-            this.onclick(new JCXEvent("click", this));
+            this.dispatchEvent(new JCXEvent("click"));
         }
-    };
-    DisplayObject.prototype.onclick = function(e) {
-        // do nothing
     };
 
     //PUBLIC METHODS

--- a/src/jcx/DisplayObject.js
+++ b/src/jcx/DisplayObject.js
@@ -2,13 +2,13 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
 
     "use strict";
 
-    // using jcx
-    
     function DisplayObject() {
         var _x, _y,
             _scaleX, _scaleY,
             _stage, _rotation,
-            _visible, _onclick;
+            _visible, _onclick,
+            _stageX, _stageY,
+            _context;
 
         _x = 0;
         _y = 0;
@@ -20,12 +20,6 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
 
         Object.defineProperties(this,
         {
-            jcx: {
-                value: null,
-                writable: true,
-                configurable: false,
-                enumerable: false
-            },
             cacheAsBitmap: {
                 value: false,
                 writable: true,
@@ -37,6 +31,19 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
                 writable: true,
                 configurable: false,
                 enumerable: true
+            },
+            context: {
+                get: function(){
+                    if (!_context){
+                        _context = this.parentContainer.context;
+                    }
+                    return _context;
+                },
+                set: function(value){
+                    _context = value;
+                },
+                configurable:false,
+                enumerable:false
             },
             height: {
                 value: null,
@@ -62,10 +69,31 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
                 configurable: false,
                 enumerable: true
             },
+            stageX: {
+                get: function(){
+                    if(_stageX == null || _stageX == undefined){
+                        _stageX = this.x + this.parentContainer.stageX;
+                    }
+                    return _stageX;
+                },
+                set: function(value){_stageX=value;},
+                configurable:true,
+                enumerable:true
+            },
+            stageY: {
+                get: function(){
+                    if(_stageY == null || _stageY == undefined){
+                        _stageY = this.y + this.parentContainer.stageY;
+                    }
+                    return _stageY;
+                },
+                set: function(value){_stageY=value;},
+                configurable:true,
+                enumerable:true
+            },
             rotation: {
                 set: function(value) {
                     _rotation = value;
-                    this.draw();
                 },
                 configurable: false,
                 enumerable: true
@@ -74,7 +102,6 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
                 get: function() { return _scaleX; },
                 set: function(value) {
                     _scaleX = value;
-                    this.draw();
                 },
                 configurable: false,
                 enumerable: true
@@ -83,7 +110,6 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
                 get: function() { return _scaleY; },
                 set: function(value){
                     _scaleY = value;
-                    this.draw();
                 },
                 configurable: false,
                 enumerable: true
@@ -157,8 +183,7 @@ define(['jcx/EventDispatcher', 'jcx/MouseEvent'], function(EventDispatcher, Mous
     });
 
     DisplayObject.prototype._isInBounds = function(x, y) {
-        // test to see if point is inbounds
-        return false;
+        return (x >= this.stageX && x <= this.stageX + this.width && y >= this.stageY && y <= this.stageY + this.height);
     };
     DisplayObject.prototype.draw = function() {
         // perform drawing logic

--- a/src/jcx/DisplayObject.js
+++ b/src/jcx/DisplayObject.js
@@ -5,7 +5,7 @@
 	// using jcx
 	// using jcx/JCXEvent
 
-	function DisplayObject(context, x, y) {
+	function DisplayObject(x, y) {
 		var _x, _y;
 
 		if( typeof(x) != "number" ) {
@@ -22,8 +22,8 @@
 		Object.defineProperties(this,
 		{
 			jcx: {
-				value: new JCX(context, x, y),
-				writable: false,
+				value: null,
+				writable: true,
 				configurable: false,
 				enumerable: false
 			},

--- a/src/jcx/DisplayObjectContainer.js
+++ b/src/jcx/DisplayObjectContainer.js
@@ -187,6 +187,7 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx/MouseEvent', 'jcx'], 
         //capture
 
         //propagation
+        //TODO: convert this to classic for loop in order to figure out which item is "on top" visually, and thus, the clicked item
         this.getObjectsUnderPoint({x:evnt.stageX, y:evnt.stageY}).forEach(function(item, index){
             var newEvent = new MouseEvent(MouseEvent.CLICK, evnt.bubbles, evnt.cacelable, evnt.stageX, evnt.stageY);
             newEvent.target = item;
@@ -204,6 +205,7 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx/MouseEvent', 'jcx'], 
         //capture
 
         //propagation
+        //TODO: convert this to classic for loop in order to figure out which item is "on top" visually, and thus, the clicked item
         this.getObjectsUnderPoint({x:evnt.stageX, y:evnt.stageY}).forEach(function(item, index){
             var newEvent = new MouseEvent(MouseEvent.MOUSE_UP, evnt.bubbles, evnt.cacelable, evnt.stageX, evnt.stageY);
             newEvent.target = item;
@@ -221,6 +223,7 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx/MouseEvent', 'jcx'], 
         //capture
 
         //propagation
+        //TODO: convert this to classic for loop in order to figure out which item is "on top" visually, and thus, the clicked item
         this.getObjectsUnderPoint({x:evnt.stageX, y:evnt.stageY}).forEach(function(item, index){
             var newEvent = new MouseEvent(MouseEvent.MOUSE_DOWN, evnt.bubbles, evnt.cacelable, evnt.stageX, evnt.stageY);
             newEvent.target = item;
@@ -238,6 +241,7 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx/MouseEvent', 'jcx'], 
         //capture
 
         //propagation
+        //TODO: need to figure out a better way to handle dragging
         this._children.filter(function(item, index){
             return item.isBeingDragged;
         }).forEach(function(item, index){

--- a/src/jcx/DisplayObjectContainer.js
+++ b/src/jcx/DisplayObjectContainer.js
@@ -238,7 +238,9 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx/MouseEvent', 'jcx'], 
         //capture
 
         //propagation
-        this.getObjectsUnderPoint({x:evnt.stageX, y:evnt.stageY}).forEach(function(item, index){
+        this._children.filter(function(item, index){
+            return item.isBeingDragged;
+        }).forEach(function(item, index){
             var newEvent = new MouseEvent(MouseEvent.MOUSE_MOVE, evnt.bubbles, evnt.cacelable, evnt.stageX, evnt.stageY);
             newEvent.target = item;
             item.notifyMouseMove(newEvent);

--- a/src/jcx/DisplayObjectContainer.js
+++ b/src/jcx/DisplayObjectContainer.js
@@ -1,4 +1,4 @@
-define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx'], function(DisplayObject, InteractiveObject, JCX){
+define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx/MouseEvent', 'jcx'], function(DisplayObject, InteractiveObject, MouseEvent, JCX){
 
     "use strict";
 
@@ -6,7 +6,7 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx'], function(DisplayOb
     // using jcx/JCXEvent
 
     function DisplayObjectContainer() {
-        var _context;
+        var _context=null, _mouseChildren=true, _tabChildren=true;
 
         Object.defineProperties(this,
         {
@@ -14,12 +14,33 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx'], function(DisplayOb
                 value: [],
                 writable: true,
                 configurable: false,
-                enumerable: false
+                enumerable: true
             },
-            parentContainer: {
-                value:null,
-                writable: true,
-                configurable:false,
+            mouseChildren: {
+                get: function(){
+                    return _mouseChildren;
+                },
+                set: function(value){
+                    _mouseChildren = value;
+                },
+                configurable:true,
+                enumerable:false
+            },
+            numChildren: {
+                get: function(){
+                    return this._children.length;
+                },
+                configurable:true,
+                enumerable:false
+            },
+            tabChildren: {
+                get: function(){
+                    return _tabChildren;
+                },
+                set: function(value){
+                    _tabChildren = value;
+                },
+                configurable:true,
                 enumerable:false
             },
             context: {
@@ -42,18 +63,34 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx'], function(DisplayOb
 
     DisplayObjectContainer.prototype = new InteractiveObject();
 
+    DisplayObjectContainer.prototype.checkIsAncestor = function(item){
+        var currentDisplayObject = this;
+        while(currentDisplayObject!==null){
+            if (currentDisplayObject === item){
+                return true;
+            }
+            currentDisplayObject = currentDisplayObject.parentContainer;
+        }
+        return false;
+    }
+
     DisplayObjectContainer.prototype.addChild = function (item) {
         if( !(item instanceof DisplayObject) ) {
             throw new Error("Cannot add non DisplayObject");
         }
-        //TODO: should throw error if 'this' is a descendent of 'item'
-        //TODO: if 'item' already has a parent, remove the item from the parent's child list
+
+        if(this.checkIsAncestor(item)){
+            throw new Error("The DisplayObject you are trying to add is an ancestor of the DisplayObject you are adding it to")
+        }
+
+        if(item.parentContainer !== null){
+            item.parentContainer.removeChild(item);
+        }
         
         item.parentContainer = this;
         item.jcx = new JCX(this.context, this.jcx.xOffset+item.x, this.jcx.yOffset+item.y);
 
         this._children.push(item);
-        //TODO: dispatch 'added' event
         return item;
     };
 
@@ -61,21 +98,24 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx'], function(DisplayOb
         if( !(item instanceof DisplayObject) ){
             throw new Error("Cannot add non DisplayObject");
         }
+
         if(index < 0 || index >= this._children.length){
             throw new Error("Argument out of range: index is either below zero, or greater than the length of the list");
         }
-        //TODO: throw error if 'this' is a decendent of 'item'
-        //TODO: if 'item' already has a parent, remove the item from the parent's child list
-        this._children.push(item);
-        for (var i = this._children.length-1; i<=index; i-=1){
-            this.swapChildrenAt(i, i-1);
+        
+        if(this.checkIsAncestor(item)){
+            throw new Error("The DisplayObject you are trying to add is an ancestor of the DisplayObject you are adding it to")
         }
-        //TODO: dispatch 'added' event
-        return item;
-    };
 
-    DisplayObjectContainer.prototype.areInaccessibleObjectsUnderPoint = function(point){
-        //TODO
+        if(item.parentContainer !== null){
+            item.parentContainer.removeChild(item);
+        }
+
+        item.parentContainer = this;
+        item.jcx = new JCX(this.context, this.jcx.xOffset+item.x, this.jcx.yOffset+item.y);
+
+        this._children.splice(index, 0, item);
+        return item;
     };
 
     DisplayObjectContainer.prototype.contains = function(child){
@@ -90,19 +130,17 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx'], function(DisplayOb
         if(index < 0 || index >= this._children.length){
             throw new Error("Argument out of range: index is either below zero, or greater than the length of the list");
         }
-        //TODO: throw security error if child is sandboxed we don't have access to it
         return this._children[index];
     };
 
     DisplayObjectContainer.prototype.getChildByName = function(name){
         var index = 0;
         var child = null;
-        for (var i = 0; i < this._children.length, i+=1)
+        for (var i = 0; i < this._children.length; i+=1){
             if(this._children[i].name == name){
                 return this._chidren[i];
             }
         }
-        //TODO throw security error if child is sandboxed and we don't have access to it
         return null;
     };
 
@@ -115,11 +153,11 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx'], function(DisplayOb
     };
 
     DisplayObjectContainer.prototype.getObjectsUnderPoint = function(point){
-        //TODO
+        return this._children.filter(function(child){return child.hitTestPoint(point.x, point.y);});
     };
 
     DisplayObjectContainer.prototype.removeChild = function(child){
-        this.removeChildAt(this.getChildIndex(child));
+        return this.removeChildAt(this.getChildIndex(child));
     };
 
 
@@ -127,17 +165,13 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx'], function(DisplayOb
         if( index < 0 || index >= this.children.length ) {
             throw new Error("Index out of range");
         }
-
-        var child = this._children[index];
-
-        delete this._children[index];
-
-        return child;
+        return this._children.splice(index, 1)[0];
     };
 
 
     DisplayObjectContainer.prototype.setChildIndex = function(child, index){
-        //TODO
+        var index2 = this.getChildIndex(child);
+        this.swapChildrenAt(index, index2);
     };
 
 
@@ -162,19 +196,21 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx'], function(DisplayOb
         }
     };
 
+    //@override
     DisplayObjectContainer.prototype.notifyClick = function(evnt) {
         var i, len;
 
-        if( this._isInBounds(evnt.x, evnt.y) ) {
-        
-            // delegate to children first
-            for( i = 0, len = this._children.length; i < len; i+=1 ) {
-                this._children[i].notifyClick(evnt);
-            }
+        //capture
 
-            // delegate to self last
-            DisplayObject.prototype.notifyClick.call(this, evnt);
-        }
+        //propagation
+        this.getObjectsUnderPoint({x:evnt.stageX, y:evnt.stageY}).every(function(item, index){
+            var newEvent = new MouseEvent(MouseEvent.CLICK, evnt.bubbles, evnt.cacelable, evnt.stageX, evnt.stageY);
+            newEvent.target = item;
+            item.notifyClick(newEvent);
+        });
+
+        //bubble
+        DisplayObject.prototype.notifyClick.call(this, evnt);
     };
 
     return DisplayObjectContainer;

--- a/src/jcx/DisplayObjectContainer.js
+++ b/src/jcx/DisplayObjectContainer.js
@@ -2,11 +2,8 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx/MouseEvent', 'jcx'], 
 
     "use strict";
 
-    // using jcx
-    // using jcx/JCXEvent
-
     function DisplayObjectContainer() {
-        var _context=null, _mouseChildren=true, _tabChildren=true;
+        var _mouseChildren=true, _tabChildren=true;
 
         Object.defineProperties(this,
         {
@@ -42,19 +39,6 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx/MouseEvent', 'jcx'], 
                 },
                 configurable:true,
                 enumerable:false
-            },
-            context: {
-                get: function(){
-                    if (!_context){
-                        _context = this.parentContainer.context;
-                    }
-                    return _context;
-                },
-                set: function(value){
-                    _context = value;
-                },
-                configurable:false,
-                enumerable:false
             }
         });
 
@@ -88,7 +72,6 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx/MouseEvent', 'jcx'], 
         }
         
         item.parentContainer = this;
-        item.jcx = new JCX(this.context, this.jcx.xOffset+item.x, this.jcx.yOffset+item.y);
 
         this._children.push(item);
         return item;
@@ -112,7 +95,8 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx/MouseEvent', 'jcx'], 
         }
 
         item.parentContainer = this;
-        item.jcx = new JCX(this.context, this.jcx.xOffset+item.x, this.jcx.yOffset+item.y);
+        item.stageX = this.stageX + item.x;
+        item.stageY = this.stageY + item.y;
 
         this._children.splice(index, 0, item);
         return item;
@@ -203,7 +187,7 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx/MouseEvent', 'jcx'], 
         //capture
 
         //propagation
-        this.getObjectsUnderPoint({x:evnt.stageX, y:evnt.stageY}).every(function(item, index){
+        this.getObjectsUnderPoint({x:evnt.stageX, y:evnt.stageY}).forEach(function(item, index){
             var newEvent = new MouseEvent(MouseEvent.CLICK, evnt.bubbles, evnt.cacelable, evnt.stageX, evnt.stageY);
             newEvent.target = item;
             item.notifyClick(newEvent);

--- a/src/jcx/DisplayObjectContainer.js
+++ b/src/jcx/DisplayObjectContainer.js
@@ -5,7 +5,7 @@
 	// using jcx
 	// using jcx/JCXEvent
 
-	function DisplayObjectContainer(context, x, y) {
+	function DisplayObjectContainer(x, y) {
 		// TODO inherit parent
 
 		Object.defineProperties(this, 
@@ -15,20 +15,45 @@
 				writable: true,
 				configurable: false,
 				enumerable: false
-			}
+			},
+            parentContainer: {
+                value:null,
+                writable: true,
+                configurable:false,
+                enumerable:false
+            },
+            context:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            getContext: {
+                value: function(){
+                    if (!this.context){
+                        return this.parentContainer.getContext();
+                    }else{
+                        return this.context;
+                    }
+                },
+                writable:false,
+                configurable:false,
+                enumerable:false
+            }
 		});
 
-		DisplayObject.call(this, context, x, y);
+		DisplayObject.call(this, x, y);
 	}
 
-	DisplayObjectContainer.prototype = new DisplayObject(null, 0, 0);	
+	DisplayObjectContainer.prototype = new DisplayObject(0, 0);	
 
 	DisplayObjectContainer.prototype.addChild = function (item) {
 		if( !(item instanceof DisplayObject) ) {
 			throw new Error("Cannot add non DisplayObject");
 		}
-
+        item.parentContainer = this;
 		this._children.push(item);
+        item.jcx = new JCX(this.getContext(), item.x, item.y);
 	};
 	DisplayObjectContainer.prototype.removeItemAt = function(index){
 		if( index < 0 || index >= this.children.length ) {

--- a/src/jcx/DisplayObjectContainer.js
+++ b/src/jcx/DisplayObjectContainer.js
@@ -1,4 +1,4 @@
-(function(){
+define(['jcx/DisplayObject', 'jcx'], function(DisplayObject, JCX){
 
 	"use strict";
 
@@ -90,5 +90,5 @@
 		}
 	};
 
-	window.DisplayObjectContainer = DisplayObjectContainer;
-}());
+    return DisplayObjectContainer;
+});

--- a/src/jcx/DisplayObjectContainer.js
+++ b/src/jcx/DisplayObjectContainer.js
@@ -197,5 +197,56 @@ define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx/MouseEvent', 'jcx'], 
         DisplayObject.prototype.notifyClick.call(this, evnt);
     };
 
+        //@override
+    DisplayObjectContainer.prototype.notifyMouseUp = function(evnt) {
+        var i, len;
+
+        //capture
+
+        //propagation
+        this.getObjectsUnderPoint({x:evnt.stageX, y:evnt.stageY}).forEach(function(item, index){
+            var newEvent = new MouseEvent(MouseEvent.MOUSE_UP, evnt.bubbles, evnt.cacelable, evnt.stageX, evnt.stageY);
+            newEvent.target = item;
+            item.notifyMouseUp(newEvent);
+        });
+
+        //bubble
+        DisplayObject.prototype.notifyMouseUp.call(this, evnt);
+    };
+
+        //@override
+    DisplayObjectContainer.prototype.notifyMouseDown = function(evnt) {
+        var i, len;
+
+        //capture
+
+        //propagation
+        this.getObjectsUnderPoint({x:evnt.stageX, y:evnt.stageY}).forEach(function(item, index){
+            var newEvent = new MouseEvent(MouseEvent.MOUSE_DOWN, evnt.bubbles, evnt.cacelable, evnt.stageX, evnt.stageY);
+            newEvent.target = item;
+            item.notifyMouseDown(newEvent);
+        });
+
+        //bubble
+        DisplayObject.prototype.notifyMouseDown.call(this, evnt);
+    };
+
+        //@override
+    DisplayObjectContainer.prototype.notifyMouseMove = function(evnt) {
+        var i, len;
+
+        //capture
+
+        //propagation
+        this.getObjectsUnderPoint({x:evnt.stageX, y:evnt.stageY}).forEach(function(item, index){
+            var newEvent = new MouseEvent(MouseEvent.MOUSE_MOVE, evnt.bubbles, evnt.cacelable, evnt.stageX, evnt.stageY);
+            newEvent.target = item;
+            item.notifyMouseMove(newEvent);
+        });
+
+        //bubble
+        DisplayObject.prototype.notifyMouseMove.call(this, evnt);
+    };
+
     return DisplayObjectContainer;
 });

--- a/src/jcx/DisplayObjectContainer.js
+++ b/src/jcx/DisplayObjectContainer.js
@@ -6,9 +6,8 @@
 	// using jcx/JCXEvent
 
 	function DisplayObjectContainer(x, y) {
-		// TODO inherit parent
 
-		Object.defineProperties(this, 
+		Object.defineProperties(this,
 		{
 			_children: {
 				value: [],
@@ -45,7 +44,7 @@
 		DisplayObject.call(this, x, y);
 	}
 
-	DisplayObjectContainer.prototype = new DisplayObject(0, 0);	
+	DisplayObjectContainer.prototype = new DisplayObject(0, 0);
 
 	DisplayObjectContainer.prototype.addChild = function (item) {
 		if( !(item instanceof DisplayObject) ) {
@@ -71,7 +70,7 @@
 
 		DisplayObject.prototype.draw.call(this);
 		
-		for(i = 0, len = this._children.length; i < len; i++ ) {
+		for(i = 0, len = this._children.length; i < len; i+=1 ) {
 			// coordinate space is relative because we called draw of container first
 			this._children[i].draw();
 		}
@@ -82,7 +81,7 @@
 		if( this._isInBounds(evnt.x, evnt.y) ) {
 		
 			// delegate to children first
-			for( i = 0, len = this._children.length; i < len; i++ ) {
+			for( i = 0, len = this._children.length; i < len; i+=1 ) {
 				this._children[i].notifyClick(evnt);
 			}
 

--- a/src/jcx/DisplayObjectContainer.js
+++ b/src/jcx/DisplayObjectContainer.js
@@ -1,94 +1,181 @@
-define(['jcx/DisplayObject', 'jcx'], function(DisplayObject, JCX){
+define(['jcx/DisplayObject', 'jcx/InteractiveObject', 'jcx'], function(DisplayObject, InteractiveObject, JCX){
 
-	"use strict";
+    "use strict";
 
-	// using jcx
-	// using jcx/JCXEvent
+    // using jcx
+    // using jcx/JCXEvent
 
-	function DisplayObjectContainer(x, y) {
+    function DisplayObjectContainer() {
+        var _context;
 
-		Object.defineProperties(this,
-		{
-			_children: {
-				value: [],
-				writable: true,
-				configurable: false,
-				enumerable: false
-			},
+        Object.defineProperties(this,
+        {
+            _children: {
+                value: [],
+                writable: true,
+                configurable: false,
+                enumerable: false
+            },
             parentContainer: {
                 value:null,
                 writable: true,
                 configurable:false,
                 enumerable:false
             },
-            context:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            },
-            getContext: {
-                value: function(){
-                    if (!this.context){
-                        return this.parentContainer.getContext();
-                    }else{
-                        return this.context;
+            context: {
+                get: function(){
+                    if (!_context){
+                        _context = this.parentContainer.context;
                     }
+                    return _context;
                 },
-                writable:false,
+                set: function(value){
+                    _context = value;
+                },
                 configurable:false,
                 enumerable:false
             }
-		});
+        });
 
-		DisplayObject.call(this, x, y);
-	}
+        InteractiveObject.call(this);
+    }
 
-	DisplayObjectContainer.prototype = new DisplayObject(0, 0);
+    DisplayObjectContainer.prototype = new InteractiveObject();
 
-	DisplayObjectContainer.prototype.addChild = function (item) {
-		if( !(item instanceof DisplayObject) ) {
-			throw new Error("Cannot add non DisplayObject");
-		}
+    DisplayObjectContainer.prototype.addChild = function (item) {
+        if( !(item instanceof DisplayObject) ) {
+            throw new Error("Cannot add non DisplayObject");
+        }
+        //TODO: should throw error if 'this' is a descendent of 'item'
+        //TODO: if 'item' already has a parent, remove the item from the parent's child list
+        
         item.parentContainer = this;
-		this._children.push(item);
-        item.jcx = new JCX(this.getContext(), item.x, item.y);
-	};
-	DisplayObjectContainer.prototype.removeItemAt = function(index){
-		if( index < 0 || index >= this.children.length ) {
-			throw new Error("Index out of range");
-		}
+        item.jcx = new JCX(this.context, this.jcx.xOffset+item.x, this.jcx.yOffset+item.y);
 
-		var child = this._children[index];
+        this._children.push(item);
+        //TODO: dispatch 'added' event
+        return item;
+    };
 
-		delete this._children[index];
+    DisplayObjectContainer.prototype.addChildAt = function(item, index){
+        if( !(item instanceof DisplayObject) ){
+            throw new Error("Cannot add non DisplayObject");
+        }
+        if(index < 0 || index >= this._children.length){
+            throw new Error("Argument out of range: index is either below zero, or greater than the length of the list");
+        }
+        //TODO: throw error if 'this' is a decendent of 'item'
+        //TODO: if 'item' already has a parent, remove the item from the parent's child list
+        this._children.push(item);
+        for (var i = this._children.length-1; i<=index; i-=1){
+            this.swapChildrenAt(i, i-1);
+        }
+        //TODO: dispatch 'added' event
+        return item;
+    };
 
-		return child;
-	};
-	DisplayObjectContainer.prototype.draw = function() {
-		var i, len;
+    DisplayObjectContainer.prototype.areInaccessibleObjectsUnderPoint = function(point){
+        //TODO
+    };
 
-		DisplayObject.prototype.draw.call(this);
-		
-		for(i = 0, len = this._children.length; i < len; i+=1 ) {
-			// coordinate space is relative because we called draw of container first
-			this._children[i].draw();
-		}
-	};
-	DisplayObjectContainer.prototype.notifyClick = function(evnt) {
-		var i, len;
+    DisplayObjectContainer.prototype.contains = function(child){
+        if(this === child) { return true; }
+        for (var c in this._children){
+            if(child === this._children[c]) { return true; }
+        }
+        return false;
+    };
 
-		if( this._isInBounds(evnt.x, evnt.y) ) {
-		
-			// delegate to children first
-			for( i = 0, len = this._children.length; i < len; i+=1 ) {
-				this._children[i].notifyClick(evnt);
-			}
+    DisplayObjectContainer.prototype.getChildAt = function(index){
+        if(index < 0 || index >= this._children.length){
+            throw new Error("Argument out of range: index is either below zero, or greater than the length of the list");
+        }
+        //TODO: throw security error if child is sandboxed we don't have access to it
+        return this._children[index];
+    };
 
-			// delegate to self last
-			DisplayObject.prototype.notifyClick.call(this, evnt);
-		}
-	};
+    DisplayObjectContainer.prototype.getChildByName = function(name){
+        var index = 0;
+        var child = null;
+        for (var i = 0; i < this._children.length, i+=1)
+            if(this._children[i].name == name){
+                return this._chidren[i];
+            }
+        }
+        //TODO throw security error if child is sandboxed and we don't have access to it
+        return null;
+    };
+
+    DisplayObjectContainer.prototype.getChildIndex = function(child){
+        var index = this._children.indexOf(child);
+        if (index < 0){
+            throw new Error("DisplayObject is not a child of this container");
+        }
+        return index;
+    };
+
+    DisplayObjectContainer.prototype.getObjectsUnderPoint = function(point){
+        //TODO
+    };
+
+    DisplayObjectContainer.prototype.removeChild = function(child){
+        this.removeChildAt(this.getChildIndex(child));
+    };
+
+
+    DisplayObjectContainer.prototype.removeChildAt = function(index){
+        if( index < 0 || index >= this.children.length ) {
+            throw new Error("Index out of range");
+        }
+
+        var child = this._children[index];
+
+        delete this._children[index];
+
+        return child;
+    };
+
+
+    DisplayObjectContainer.prototype.setChildIndex = function(child, index){
+        //TODO
+    };
+
+
+    DisplayObjectContainer.prototype.swapChildren = function(child1, child2){
+        this.swapChildrenAt(this.getChildIndex(child1), this.getChildIndex(child2));
+    };
+
+    DisplayObjectContainer.prototype.swapChildrenAt = function(index1, index2){
+        var child1 = this._children[index1];
+        this._children[index1] = this._children[index2];
+        this._children[index2] = child1;
+    };
+
+    DisplayObjectContainer.prototype.draw = function() {
+        var i, len;
+
+        DisplayObject.prototype.draw.call(this);
+        
+        for(i = 0, len = this._children.length; i < len; i+=1 ) {
+            // coordinate space is relative because we called draw of container first
+            this._children[i].draw();
+        }
+    };
+
+    DisplayObjectContainer.prototype.notifyClick = function(evnt) {
+        var i, len;
+
+        if( this._isInBounds(evnt.x, evnt.y) ) {
+        
+            // delegate to children first
+            for( i = 0, len = this._children.length; i < len; i+=1 ) {
+                this._children[i].notifyClick(evnt);
+            }
+
+            // delegate to self last
+            DisplayObject.prototype.notifyClick.call(this, evnt);
+        }
+    };
 
     return DisplayObjectContainer;
 });

--- a/src/jcx/EventDispatcher.js
+++ b/src/jcx/EventDispatcher.js
@@ -7,6 +7,8 @@ define(function(){
         if(target){
             //aggregate instance
         }
+        
+        this._eventListeners = {};
     }
 
     EventDispatcher.prototype = {
@@ -19,10 +21,14 @@ define(function(){
             if(!useCapture){ useCapture = false; }
             if(!priority){ priority = 0; }
             if(!useWeakReference){ useWeakReference = false; }
+            this._eventListeners[type] = listener;
         },
-        //event:Event
-        dispatchEvent:function(event){
-
+        //event:JCXEvent
+        dispatchEvent:function(jcxEvent){
+            jcxEvent.target = this;
+            if(this._eventListeners[jcxEvent.type]!==null && this._eventListeners[jcxEvent.type]!==undefined){
+                this._eventListeners[jcxEvent.type](jcxEvent);
+            }
         },
         //type:string
         hasEventListener:function(type){
@@ -33,11 +39,13 @@ define(function(){
         //useCapture:boolean
         removeEventListener:function(type, listener, useCapture){
             if(!useCapture){ useCapture = false; }
+            delete this._eventListeners[type];
         },
         //type:string
         willTrigger:function(type){
 
-        }
+        },
+        _eventListeners:{}
     };
     return EventDispatcher;
 });

--- a/src/jcx/EventDispatcher.js
+++ b/src/jcx/EventDispatcher.js
@@ -1,0 +1,42 @@
+(function(){
+    "use strict";
+
+    //target is an IEventDispatcher
+    //not necessary for constructor
+    function EventDispatcher(target){
+        if(target){
+            //aggregate instance
+        }
+    }
+
+    EventDispatcher.prototype = {
+        //type:string
+        //listener:function
+        //useCapture:boolean
+        //priority:int
+        //useWeakReference:boolean
+        addEventListener:function(type, listener, useCapture, priority, useWeakReference){
+            if(!useCapture){ useCapture = false; }
+            if(!priority){ priority = 0; }
+            if(!useWeakReference){ useWeakReference = false; }
+        },
+        //event:Event
+        dispatchEvent:function(event){
+
+        },
+        //type:string
+        hasEventListener:function(type){
+            
+        },
+        //type:string
+        //listener:function
+        //useCapture:boolean
+        removeEventListener:function(type, listener, useCapture){
+            if(!useCapture){ useCapture = false; }
+        },
+        //type:string
+        willTrigger:function(type){
+
+        }
+    };
+}());

--- a/src/jcx/EventDispatcher.js
+++ b/src/jcx/EventDispatcher.js
@@ -1,4 +1,4 @@
-(function(){
+define(function(){
     "use strict";
 
     //target is an IEventDispatcher
@@ -39,4 +39,5 @@
 
         }
     };
-}());
+    return EventDispatcher;
+});

--- a/src/jcx/EventPhase.js
+++ b/src/jcx/EventPhase.js
@@ -1,0 +1,5 @@
+define({
+    AT_TARGET:2,
+    BUBBLING_PHASE:3,
+    CAPTURING_PHASE:1
+});

--- a/src/jcx/InteractiveObject.js
+++ b/src/jcx/InteractiveObject.js
@@ -2,71 +2,11 @@ define(['jcx/DisplayObject'],function(DisplayObject){
     "use strict";
 
     function InteractiveObject(){
-        Object.defineProperties(this,{
-            accessibilityImplementation:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            },
-            contextMenu:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            },
-            doubleClickEnabled:{
-                value:false,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            },
-            focusRect:{
-                value:false,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            },
-            mouseEnabled:{
-                value:false,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            },
-            needsSoftKeyboard:{
-                value:false,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            },
-            softKeyboardInputAreaOfInterest:{
-                value:false,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            },
-            tabEnabled:{
-                value:false,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            },
-            tabIndex:{
-                value:false,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            }
-        });
-    
         DisplayObject.call(this);
     }
 
     //set prototype here
     InteractiveObject.prototype = new DisplayObject();
-    InteractiveObject.prototype.requestSoftKeyboard = function(){
-        //raise a virtual keyboard
-    };
 
     return InteractiveObject;
 });

--- a/src/jcx/InteractiveObject.js
+++ b/src/jcx/InteractiveObject.js
@@ -1,13 +1,72 @@
-(function(){
+define(['jcx/DisplayObject'],function(DisplayObject){
     "use strict";
 
     function InteractiveObject(){
-        Object.defineProperties(this,
-        {
-            
+        Object.defineProperties(this,{
+            accessibilityImplementation:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            contextMenu:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            doubleClickEnabled:{
+                value:false,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            focusRect:{
+                value:false,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            mouseEnabled:{
+                value:false,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            needsSoftKeyboard:{
+                value:false,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            softKeyboardInputAreaOfInterest:{
+                value:false,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            tabEnabled:{
+                value:false,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            tabIndex:{
+                value:false,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            }
         });
-        //call parent constructor
+    
+        DisplayObject.call(this);
     }
 
     //set prototype here
-}());
+    InteractiveObject.prototype = new DisplayObject();
+    InteractiveObject.prototype.requestSoftKeyboard = function(){
+        //raise a virtual keyboard
+    };
+
+    return InteractiveObject;
+});

--- a/src/jcx/InteractiveObject.js
+++ b/src/jcx/InteractiveObject.js
@@ -1,0 +1,13 @@
+(function(){
+    "use strict";
+
+    function InteractiveObject(){
+        Object.defineProperties(this,
+        {
+            
+        });
+        //call parent constructor
+    }
+
+    //set prototype here
+}());

--- a/src/jcx/JCXEvent.js
+++ b/src/jcx/JCXEvent.js
@@ -1,17 +1,19 @@
 define(function(){
-	
-	"use strict";
+    
+    "use strict";
 
-	function JCXEvent(type, bubbles, cancelable) {
+    function JCXEvent(type, bubbles, cancelable) {
         if(bubbles === null || bubbles === undefined){
             bubbles = false;
         }
         if(cancelable === null || cancelable === undefined){
             cancelable = false;
         }
+        var _targetLocked = false;
+        var _target;
 
-		Object.defineProperties(this,
-		{
+        Object.defineProperties(this,
+        {
             bubbles: {
                 value:bubbles,
                 writable:false,
@@ -37,8 +39,13 @@ define(function(){
                 enumerable:false
             },
             target: {
-                value: null,
-                writable: false,
+                get: function(){ return _target; },
+                set: function(value){
+                    if(_target!==null && !_targetLocked){
+                        _target = value;
+                        _targetLocked = true;
+                    }
+                },
                 configurable: false,
                 enumerable: false
             },
@@ -48,8 +55,8 @@ define(function(){
                 configurable: false,
                 enumerable: false
             }
-		});
-	}
+        });
+    }
 
     JCXEvent.ACTIVATE = "activate";
     JCXEvent.ADDED = "added";

--- a/src/jcx/JCXEvent.js
+++ b/src/jcx/JCXEvent.js
@@ -1,4 +1,4 @@
-(function(){
+define(function(){
 	
 	"use strict";
 
@@ -100,6 +100,5 @@
     JCXEvent.USER_IDLE = "userIdle";
     JCXEvent.USER_PRESENT = "userPresent";
 
-	window.JCXEvent = JCXEvent;
-
-}());
+    return JCXEvent;
+});

--- a/src/jcx/JCXEvent.js
+++ b/src/jcx/JCXEvent.js
@@ -2,26 +2,103 @@
 	
 	"use strict";
 
-	function JCXEvent(name, source) {
-		var _name, _source;
-
-		_name = name;
-		_source = source;
+	function JCXEvent(type, bubbles, cancelable) {
+        if(bubbles === null || bubbles === undefined){
+            bubbles = false;
+        }
+        if(cancelable === null || cancelable === undefined){
+            cancelable = false;
+        }
 
 		Object.defineProperties(this,
 		{
-			name: {
-				get: function(){return _name;},
-				configurable: false,
-				enumerable: false
-			},
-			source: {
-				get: function(){return _source;},
-				configurable: false,
-				enumerable: false
-			}
+            bubbles: {
+                value:bubbles,
+                writable:false,
+                configurable:false,
+                enumerable:false
+            },
+            cancelable:{
+                value: cancelable,
+                writable: false,
+                configurable: false,
+                enumerable: false
+            },
+            currentTarget: {
+                value: false,
+                writable: false,
+                configurable: false,
+                enumerable: false
+            },
+            eventPhase: {
+                value: 0,
+                writable:false,
+                configurable: false,
+                enumerable:false
+            },
+            target: {
+                value: null,
+                writable: false,
+                configurable: false,
+                enumerable: false
+            },
+            type: {
+                value: type,
+                writable:false,
+                configurable: false,
+                enumerable: false
+            }
 		});
 	}
+
+    JCXEvent.ACTIVATE = "activate";
+    JCXEvent.ADDED = "added";
+    JCXEvent.ADDED_TO_STAGE = "addedToStage";
+    JCXEvent.CANCEL = "cancel";
+    JCXEvent.CHANGE = "change";
+    JCXEvent.CLEAR = "clear";
+    JCXEvent.CLOSE = "close";
+    JCXEvent.CLOSING = "closing";
+    JCXEvent.COMPLETE = "complete";
+    JCXEvent.CONNECT = "connect";
+    JCXEvent.CONTEXT3D_CREATE = "context3DCreate";
+    JCXEvent.COPY = "copy";
+    JCXEvent.CUT = "cut";
+    JCXEvent.DEACTIVATE = "deactivate";
+    JCXEvent.DISPLAYING = "displaying";
+    JCXEvent.ENTER_FRAME = "enterFame";
+    JCXEvent.EXIT_FRAME = "exitFrame";
+    JCXEvent.FRAME_CONSTRUCTED = "frameConstructed";
+    JCXEvent.FULLSCREEN = "fullscreen";
+    JCXEvent.HTML_BOUNDS_CHANGE = "htmlBoundsChange";
+    JCXEvent.HTML_DOM_INITIALIZE = "htmlDOMInitialize";
+    JCXEvent.HTML_RENDER = "htmlRender";
+    JCXEvent.ID3 = "id3";
+    JCXEvent.INIT = "init";
+    JCXEvent.LOCATION_CHANGE = "locationChange";
+    JCXEvent.MOUSE_LEAVE = "mouseLeave";
+    JCXEvent.NETWORK_CHANGE = "networkChange";
+    JCXEvent.OPEN = "open";
+    JCXEvent.PASTE = "paste";
+    JCXEvent.PREPARING = "preparing";
+    JCXEvent.REMOVED = "removed";
+    JCXEvent.RENDER = "render";
+    JCXEvent.RESIZE = "resize";
+    JCXEvent.SCROLL = "scroll";
+    JCXEvent.SELECT = "select";
+    JCXEvent.SELECT_ALL = "selectAll";
+    JCXEvent.SOUND_COMPLETE = "soundComplete";
+    JCXEvent.STANDARD_ERROR_CLOSE = "standardErrorClose";
+    JCXEvent.STANDARD_INPUT_CLOSE = "standardInputClose";
+    JCXEvent.STANDARD_OUTPUT_CLOSE = "standardOutputClose";
+    JCXEvent.TAB_CHILDREN_CHANGE = "tabChildrenChange";
+    JCXEvent.TAB_ENABLED_CHANGE = "tabEnabledChange";
+    JCXEvent.TAB_INDEX_CHANGE = "tabIndexChange";
+    JCXEvent.TEXT_INTERACTION_MODE_CHANGE = "textInteractionModeChange";
+    JCXEvent.TEXTURE_READY = "textureReady";
+    JCXEvent.UNLOAD = "unload";
+    JCXEvent.USER_IDLE = "userIdle";
+    JCXEvent.USER_PRESENT = "userPresent";
 
 	window.JCXEvent = JCXEvent;
 

--- a/src/jcx/MouseEvent.js
+++ b/src/jcx/MouseEvent.js
@@ -1,7 +1,7 @@
 define(["jcx/JCXEvent"],function(JCXEvent){
     "use strict";
 
-    function MouseEvent(type, bubbles, cancelable, localX, localY, relatedObject, ctrlKey, altKey, shiftKey, buttonDown, delta, commandKey, controlKey, clickCount){
+    function MouseEvent(type, bubbles, cancelable, stageX, stageY, relatedObject, ctrlKey, altKey, shiftKey, buttonDown, delta, commandKey, controlKey, clickCount){
         Object.defineProperties(this,
         {
             altKey:{
@@ -46,20 +46,14 @@ define(["jcx/JCXEvent"],function(JCXEvent){
                 configurable:false,
                 enumerable:false
             },
-            isRelatedObjectInaccessible:{
-                value:false,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            },
             localX:{
-                value:localX,
+                value:null,
                 writable:true,
                 configurable:false,
                 enumerable:false
             },
             localY:{
-                value:localY,
+                value:null,
                 writable:true,
                 configurable:false,
                 enumerable:false
@@ -77,13 +71,13 @@ define(["jcx/JCXEvent"],function(JCXEvent){
                 enumerable:false
             },
             stageX:{
-                value:null,//TODO
+                value:stageX,
                 writable:false,
                 configurable:false,
                 enumerable:false
             },
             stageY:{
-                value:null,//TODO
+                value:stageY,
                 writable:false,
                 configurable:false,
                 enumerable:false

--- a/src/jcx/MouseEvent.js
+++ b/src/jcx/MouseEvent.js
@@ -1,0 +1,124 @@
+define(["jcx/JCXEvent"],function(JCXEvent){
+    "use strict";
+
+    function MouseEvent(type, bubbles, cancelable, localX, localY, relatedObject, ctrlKey, altKey, shiftKey, buttonDown, delta, commandKey, controlKey, clickCount){
+        Object.defineProperties(this,
+        {
+            altKey:{
+                value:altKey,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            buttonDown:{
+                value:buttonDown,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            clickCount:{
+                value:clickCount,
+                writable:false,
+                configurable:false,
+                enumerable:false
+            },
+            commandKey:{
+                value:commandKey,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            controlKey:{
+                value:controlKey,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            ctrlKey:{
+                value:ctrlKey,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            delta:{
+                value:delta,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            isRelatedObjectInaccessible:{
+                value:false,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            localX:{
+                value:localX,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            localY:{
+                value:localY,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            relatedObject:{
+                value:relatedObject,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            shiftKey:{
+                value:shiftKey,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            stageX:{
+                value:null,//TODO
+                writable:false,
+                configurable:false,
+                enumerable:false
+            },
+            stageY:{
+                value:null,//TODO
+                writable:false,
+                configurable:false,
+                enumerable:false
+            }
+            
+        });
+        JCXEvent.call(this, type, bubbles, cancelable);
+    }
+
+    MouseEvent.prototype = new JCXEvent(null);
+
+    //@override
+    MouseEvent.prototype.clone = function(){ };
+    //@override
+    MouseEvent.prototype.toString = function(){ };
+    //@override
+    MouseEvent.prototype.updateAfterEvent = function(){ };
+
+    MouseEvent.CLICK = "click";
+    MouseEvent.CONTEXT_MENU = "contextMenu";
+    MouseEvent.DOUBLE_CLICK = "doubleClick";
+    MouseEvent.MIDDLE_CLICK = "middleClick";
+    MouseEvent.MIDDLE_MOUSE_DOWN = "middleMouseDown";
+    MouseEvent.MIDDLE_MOUSE_UP = "middleMouseUp";
+    MouseEvent.MOUSE_DOWN = "mouseDown";
+    MouseEvent.MOUSE_MOVE = "mouseMove";
+    MouseEvent.MOUSE_OUT = "mouseOut";
+    MouseEvent.MOUSE_OVER = "mouseOver";
+    MouseEvent.MOUSE_UP = "mouseUp";
+    MouseEvent.MOUSE_WHEEL = "mouseWheel";
+    MouseEvent.RIGHT_CLICK = "rightClick";
+    MouseEvent.RIGHT_MOUSE_DOWN = "rightMouseDown";
+    MouseEvent.RIGHT_MOUSE_UP = "rightMouseUp";
+    MouseEvent.ROLL_OUT = "rollOut";
+    MouseEvent.ROLL_OVER = "rollOver";
+
+    return MouseEvent;
+});

--- a/src/jcx/RenderableObject.js
+++ b/src/jcx/RenderableObject.js
@@ -1,0 +1,27 @@
+define(['jcx/DisplayObject', 'jcx'],function(DisplayObject, JCX){
+	
+	"use strict";
+
+	function RenderableObject(){
+		var _jcx;
+		Object.defineProperties(this,
+		{
+			jcx:{
+				get: function(){
+					if(_jcx == null || _jcx == undefined){
+						_jcx = new JCX(this.context);
+					}
+					return _jcx;
+				},
+				configurable:false,
+				enumerable:true
+			}
+		});
+
+		DisplayObject.call(this);
+	}
+
+	RenderableObject.prototype = new DisplayObject();
+
+	return RenderableObject;
+});

--- a/src/jcx/RenderableObject.js
+++ b/src/jcx/RenderableObject.js
@@ -15,7 +15,13 @@ define(['jcx/DisplayObject', 'jcx'],function(DisplayObject, JCX){
 				},
 				configurable:false,
 				enumerable:true
-			}
+			},
+			renderer: {
+                value: null,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
 		});
 
 		DisplayObject.call(this);

--- a/src/jcx/Shape.js
+++ b/src/jcx/Shape.js
@@ -1,18 +1,8 @@
-define(['jcx/DisplayObject', 'jcx'], function(DisplayObject, JCX){
+define(['jcx/RenderableObject', 'jcx'], function(RenderableObject, JCX){
 
     function Shape(){
         var _jcx;
         Object.defineProperties(this,{
-            jcx: {
-                get: function(){
-                    if (_jcx == null || _jcx == undefined){
-                        _jcx = new JCX(this.context);
-                    }
-                    return _jcx;
-                },
-                configurable:false,
-                enumerable:true
-            },
             color : {
                 value:"#000",
                 writable:true,
@@ -32,14 +22,14 @@ define(['jcx/DisplayObject', 'jcx'], function(DisplayObject, JCX){
                 enumerable:false
             }
         });
-        DisplayObject.call(this);
+        RenderableObject.call(this);
     }
     
-    Shape.prototype = new DisplayObject();
+    Shape.prototype = new RenderableObject();
     //@override
     Shape.prototype.draw = function(){
         this.renderer(this.jcx);
-        DisplayObject.prototype.draw.call(this);
+        RenderableObject.prototype.draw.call(this);
     };
 
     //@override

--- a/src/jcx/Shape.js
+++ b/src/jcx/Shape.js
@@ -9,12 +9,6 @@ define(['jcx/RenderableObject', 'jcx'], function(RenderableObject, JCX){
                 configurable:false,
                 enumerable:true
             },
-            renderer: {
-                value: null,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            },
             isInBoundsTester: {
                 value:null,
                 writable:true,

--- a/src/jcx/Shape.js
+++ b/src/jcx/Shape.js
@@ -1,0 +1,50 @@
+define(['jcx/DisplayObject', 'jcx'], function(DisplayObject, JCX){
+
+    function Shape(){
+        var _jcx;
+        Object.defineProperties(this,{
+            jcx: {
+                get: function(){
+                    if (_jcx == null || _jcx == undefined){
+                        _jcx = new JCX(this.context);
+                    }
+                    return _jcx;
+                },
+                configurable:false,
+                enumerable:true
+            },
+            color : {
+                value:"#000",
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            renderer: {
+                value: null,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            isInBoundsTester: {
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            }
+        });
+        DisplayObject.call(this);
+    }
+    
+    Shape.prototype = new DisplayObject();
+    //@override
+    Shape.prototype.draw = function(){
+        this.renderer(this.jcx);
+        DisplayObject.prototype.draw.call(this);
+    }
+
+    //@override
+    Shape.prototype._isInBounds = function(x, y){
+        return this.isInBoundsTester(x, y);
+    }
+    return Shape;
+});

--- a/src/jcx/Shape.js
+++ b/src/jcx/Shape.js
@@ -40,11 +40,11 @@ define(['jcx/DisplayObject', 'jcx'], function(DisplayObject, JCX){
     Shape.prototype.draw = function(){
         this.renderer(this.jcx);
         DisplayObject.prototype.draw.call(this);
-    }
+    };
 
     //@override
     Shape.prototype._isInBounds = function(x, y){
         return this.isInBoundsTester(x, y);
-    }
+    };
     return Shape;
 });

--- a/src/jcx/Stage.js
+++ b/src/jcx/Stage.js
@@ -56,15 +56,27 @@ define(['jcx', 'jcx/DisplayObjectContainer', 'jcx/MouseEvent'], function(JCX, Di
                 configurable:false,
                 enumerable:true
             },
+            stageX: {
+                value:0,
+                writable:false,
+                configurable:false,
+                enumerable:false
+            },
+            stageY: {
+                value:0,
+                writable:false,
+                configurable:false,
+                enumerable:false
+            }
         });
 
         // ensure the width/height is correct
         canvas.style.width = canvas.width;
         canvas.style.height = canvas.height;
+        this.height = canvas.height;
+        this.width = canvas.width;
 
         this.context = canvas.getContext("2d");
-
-        this.jcx = new JCX(this._context,0,0);
 
         // setup click handler
         var that = this;

--- a/src/jcx/Stage.js
+++ b/src/jcx/Stage.js
@@ -1,7 +1,5 @@
 // A canvas wrapper for object drawing
-(function(){
-
-	// using jcx.js
+define(['jcx', 'jcx/DisplayObjectContainer'], function(JCX, DisplayObjectContainer){
 
 	function Stage(canvas) {
 
@@ -11,7 +9,7 @@
 		canvas.style.width = canvas.width;
 		canvas.style.height = canvas.height;
 
-        this.context = canvas.getContext("2d");	
+        this.context = canvas.getContext("2d");
 
         this.jcx = new JCX(this._context,0,0);
 
@@ -22,12 +20,11 @@
 		};
 
 		// immediately draw the canvas
-		DisplayObjectContainer.prototype.draw.call(this); 
+		DisplayObjectContainer.prototype.draw.call(this);
 	}
 	
 	Stage.prototype = new DisplayObjectContainer(0, 0);
 
 	Stage.prototype._isInBounds = function(x, y) { return true; };
-
-	window.Stage = Stage;
-}());
+    return Stage;
+});

--- a/src/jcx/Stage.js
+++ b/src/jcx/Stage.js
@@ -4,11 +4,16 @@
 	// using jcx.js
 
 	function Stage(canvas) {
-		DisplayObjectContainer.call(this, canvas.getContext("2d"), 0, 0);
+
+		DisplayObjectContainer.call(this, 0, 0);
 
 		// ensure the width/height is correct
 		canvas.style.width = canvas.width;
 		canvas.style.height = canvas.height;
+
+        this.context = canvas.getContext("2d");	
+
+        this.jcx = new JCX(this._context,0,0);
 
 		// setup click handler
 		var that = this;
@@ -20,9 +25,9 @@
 		DisplayObjectContainer.prototype.draw.call(this); 
 	}
 	
-	Stage.prototype = new DisplayObjectContainer(null, 0, 0);
+	Stage.prototype = new DisplayObjectContainer(0, 0);
 
 	Stage.prototype._isInBounds = function(x, y) { return true; };
-	
+
 	window.Stage = Stage;
 }());

--- a/src/jcx/Stage.js
+++ b/src/jcx/Stage.js
@@ -81,20 +81,24 @@ define(['jcx', 'jcx/DisplayObjectContainer', 'jcx/MouseEvent'], function(JCX, Di
         // setup click handler
         var that = this;
         canvas.onclick = function(e) {
-            that.notifyClick(new MouseEvent(MouseEvent.CLICK, false, false, e.x, e.y));
+            var mouseClickEvent = new MouseEvent(MouseEvent.CLICK, false, false, e.x, e.y);
+            mouseClickEvent.target = that;
+            that.notifyClick(mouseClickEvent);
         };
         canvas.onmousedown = function(e){
-            that.notifyMouseDown(new MouseEvent(MouseEvent.MOUSE_DOWN, false, false, e.x, e.y));
+            var mouseDownEvent = new MouseEvent(MouseEvent.MOUSE_DOWN, false, false, e.x, e.y);
+            mouseDownEvent.target = that;
+            that.notifyMouseDown(mouseDownEvent);
         };
         canvas.onmouseup = function(e){
-            that.notifyMouseUp(new MouseEvent(MouseEvent.MOUSE_UP, false, false, e.x, e.y));
+            var mouseUpEvent = new MouseEvent(MouseEvent.MOUSE_UP, false, false, e.x, e.y);
+            mouseUpEvent.target = that;
+            that.notifyMouseUp(mouseUpEvent);
         };
         canvas.onmousemove = function(e){
-            for (var c in that._children){
-                if(that._children[c].isBeingDragged){
-                    that._children[c].notifyMouseMove(new MouseEvent(MouseEvent.MOUSE_MOVE, false, false, e.x, e.y));
-                }
-            }
+            var mouseMoveEvent = new MouseEvent(MouseEvent.MOUSE_MOVE, false, false, e.x, e.y)
+            mouseMoveEvent.target = that;
+            that.notifyMouseMove(mouseMoveEvent);
         };
     }
     

--- a/src/jcx/Stage.js
+++ b/src/jcx/Stage.js
@@ -81,21 +81,29 @@ define(['jcx', 'jcx/DisplayObjectContainer', 'jcx/MouseEvent'], function(JCX, Di
         // setup click handler
         var that = this;
         canvas.onclick = function(e) {
+            //TODO: this should function should first find the target via graph traversal,
+            //search for a cached path to it, and then execute the event path
             var mouseClickEvent = new MouseEvent(MouseEvent.CLICK, false, false, e.x, e.y);
             mouseClickEvent.target = that;
             that.notifyClick(mouseClickEvent);
         };
         canvas.onmousedown = function(e){
+            //TODO: this should function should first find the target via graph traversal,
+            //search for a cached path to it, and then execute the event path
             var mouseDownEvent = new MouseEvent(MouseEvent.MOUSE_DOWN, false, false, e.x, e.y);
             mouseDownEvent.target = that;
             that.notifyMouseDown(mouseDownEvent);
         };
         canvas.onmouseup = function(e){
+            //TODO: this should function should first find the target via graph traversal,
+            //search for a cached path to it, and then execute the event path
             var mouseUpEvent = new MouseEvent(MouseEvent.MOUSE_UP, false, false, e.x, e.y);
             mouseUpEvent.target = that;
             that.notifyMouseUp(mouseUpEvent);
         };
         canvas.onmousemove = function(e){
+            //TODO: this should function should first find the target via graph traversal,
+            //search for a cached path to it, and then execute the event path
             var mouseMoveEvent = new MouseEvent(MouseEvent.MOUSE_MOVE, false, false, e.x, e.y)
             mouseMoveEvent.target = that;
             that.notifyMouseMove(mouseMoveEvent);

--- a/src/jcx/Stage.js
+++ b/src/jcx/Stage.js
@@ -1,65 +1,17 @@
 // A canvas wrapper for object drawing
-define(['jcx', 'jcx/DisplayObjectContainer'], function(JCX, DisplayObjectContainer){
+define(['jcx', 'jcx/DisplayObjectContainer', 'jcx/MouseEvent'], function(JCX, DisplayObjectContainer, MouseEvent){
 
     function Stage(canvas) {
 
         DisplayObjectContainer.call(this);
         Object.defineProperties(this,{
-            align:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable: true
-            },
-            allowsFullScreen:{
-                value: false,
-                writable:false,
-                configurable:false,
-                enumerable: true
-            },
-            allowsFullScreenInteractive:{
-                value:false,
-                writable:true,
-                configurable:false,
-                enumerable:true
-            },
-            autoOrients:{
-                value:false,
-                writable: true,
-                configurable:false,
-                enumerable: true
-            },
             color:{
                 value:"#ffffff",
                 writable:true,
                 configurable:false,
                 enumerable: true
             },
-            colorCorrection:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:true
-            },
-            colorCorrectionSupport:{
-                value:null,
-                writable:false,
-                configurable:false,
-                enumerable:true
-            },
             constructor:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:true
-            },
-            deviceOrientation:{
-                value:null,
-                writable:false,
-                configurable:false,
-                enumerable:true
-            },
-            displayState:{
                 value:null,
                 writable:true,
                 configurable:false,
@@ -77,30 +29,7 @@ define(['jcx', 'jcx/DisplayObjectContainer'], function(JCX, DisplayObjectContain
                 configurable:false,
                 enumerable:true
             },
-            fullScreenHeight:{
-                value:null,
-                writable:false,
-                configurable:false,
-                enumerable:true
-            },
-            fullScreenSourceRect:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:true
-            },
-            fullScreenWidth:{
-                value:null,
-                writable:false,
-                configurable:false,
-                enumerable:true
-            },
-            height:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:true
-            },
+            //@override
             mouseChildren:{
                 value:null,
                 writable:true,
@@ -113,103 +42,20 @@ define(['jcx', 'jcx/DisplayObjectContainer'], function(JCX, DisplayObjectContain
                 configurable:false,
                 enumerable:true
             },
+            //@override
             numChildren:{
                 value:null,
                 writable:false,
                 configurable:false,
                 enumerable:true
             },
-            orientation:{
-                value:null,
-                writable:false,
-                configurable:false,
-                enumerable:true
-            },
-            quality:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:true
-            },
-            scaleMode:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:true
-            },
-            showDefaultContextMenu:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:true
-            },
-            softKeyboardRect:{
-                value:null,
-                writable:false,
-                configurable:false,
-                enumerable:true
-            },
-            stageFocusRect:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:true
-            },
-            stageHeight:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:true
-            },
-            stageVideos:{
-                value:null,
-                writable:false,
-                configurable:false,
-                enumerable:true
-            },
-            stageWidth:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:true
-            },
-
-            supportedOrientations:{
-                value:null,
-                writable:false,
-                configurable:false,
-                enumerable:true
-            },
-            supportsOrientationChange:{
-                value:null,
-                writable:false,
-                configurable:false,
-                enumerable:true
-            },
+            //@override
             tabChildren:{
                 value:null,
                 writable:true,
                 configurable:false,
                 enumerable:true
             },
-            textSnapshot:{
-                value:null,
-                writable:false,
-                configurable:false,
-                enumerable:true
-            },
-            width:{
-                value:null,
-                writable:true,
-                configurable:false,
-                enumerable:true
-            },
-            wmodeGPU:{
-                value:null,
-                writable:false,
-                configurable:false,
-                enumerable:true
-            }
         });
 
         // ensure the width/height is correct
@@ -223,7 +69,7 @@ define(['jcx', 'jcx/DisplayObjectContainer'], function(JCX, DisplayObjectContain
         // setup click handler
         var that = this;
         canvas.onclick = function(e) {
-            that.notifyClick(e);
+            that.notifyClick(new MouseEvent(MouseEvent.CLICK, false, false, e.x, e.y));
         };
 
         // immediately draw the canvas
@@ -232,71 +78,16 @@ define(['jcx', 'jcx/DisplayObjectContainer'], function(JCX, DisplayObjectContain
     
     Stage.prototype = new DisplayObjectContainer();
 
-    Stage.prototype._isInBounds = function(x, y) { return true; };
-
     //@override
     Stage.prototype.addChild = function(item){
         DisplayObjectContainer.prototype.addChild.call(this, item);
-        //TODO
+        item.stage = this;
     };
 
     //@override
-    Stage.prototype.addChildAt = function(child, index){
-        //TODO what does this override?
-    };
-
-    //@override
-    Stage.prototype.addEventListener = function(type, listener, useCapture, priority, useWeakReference){
-        DisplayObjectContainer.prototype.addEventListener(this, type, listener, useCapture, priority, useWeakReference);
-        //TODO
-    };
-
-    Stage.prototype.assignFocus = function(objectToFocus, direction){
-        //TODO
-    };
-
-    //@override
-    Stage.prototype.dispatchEvent = function(evnt){
-        //TODO
-    };
-
-    //@override
-    Stage.prototype.hasEventListener = function(type){
-        //TODO
-    };
-
-    Stage.prototype.invalidate = function(){
-        //TODO
-    };
-
-    Stage.prototype.isFocusInaccessible = function(){
-        //TODO
-    };
-    //@override
-    Stage.prototype.removeChildAt = function(index){
-        //TODO
-    };
-
-    Stage.prototype.setAspectRatio = function(newAspectRatio){
-        //TODO
-    };
-
-    //@override
-    Stage.prototype.setChildIndex = function(child, index){
-        //TODO
-    };
-
-    Stage.prototype.setOrientation = function(newOrientation){
-        //TODO
-    };
-    
-    //@override
-    Stage.prototype.swapChildrenAt = function(index1, index2){
-        //TODO
-    };
-
-    Stage.prototype.willTrigger = function(type){
-        //TODO
+    Stage.prototype.addChildAt = function(item, index){
+        DisplayObjectContainer.prototype.addChildAt.call(this, item, index);
+        item.stage = this;
     };
 
     return Stage;

--- a/src/jcx/Stage.js
+++ b/src/jcx/Stage.js
@@ -83,12 +83,28 @@ define(['jcx', 'jcx/DisplayObjectContainer', 'jcx/MouseEvent'], function(JCX, Di
         canvas.onclick = function(e) {
             that.notifyClick(new MouseEvent(MouseEvent.CLICK, false, false, e.x, e.y));
         };
-
-        // immediately draw the canvas
-        DisplayObjectContainer.prototype.draw.call(this);
+        canvas.onmousedown = function(e){
+            that.notifyMouseDown(new MouseEvent(MouseEvent.MOUSE_DOWN, false, false, e.x, e.y));
+        };
+        canvas.onmouseup = function(e){
+            that.notifyMouseUp(new MouseEvent(MouseEvent.MOUSE_UP, false, false, e.x, e.y));
+        };
+        canvas.onmousemove = function(e){
+            for (var c in that._children){
+                if(that._children[c].isBeingDragged){
+                    that._children[c].notifyMouseMove(new MouseEvent(MouseEvent.MOUSE_MOVE, false, false, e.x, e.y));
+                }
+            }
+        };
     }
     
     Stage.prototype = new DisplayObjectContainer();
+
+    //@override
+    Stage.prototype.draw = function(){
+        this.context.clearRect(0, 0, this.width, this.height);
+        DisplayObjectContainer.prototype.draw.call(this);
+    };
 
     //@override
     Stage.prototype.addChild = function(item){

--- a/src/jcx/Stage.js
+++ b/src/jcx/Stage.js
@@ -1,30 +1,303 @@
 // A canvas wrapper for object drawing
 define(['jcx', 'jcx/DisplayObjectContainer'], function(JCX, DisplayObjectContainer){
 
-	function Stage(canvas) {
+    function Stage(canvas) {
 
-		DisplayObjectContainer.call(this, 0, 0);
+        DisplayObjectContainer.call(this);
+        Object.defineProperties(this,{
+            align:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable: true
+            },
+            allowsFullScreen:{
+                value: false,
+                writable:false,
+                configurable:false,
+                enumerable: true
+            },
+            allowsFullScreenInteractive:{
+                value:false,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            autoOrients:{
+                value:false,
+                writable: true,
+                configurable:false,
+                enumerable: true
+            },
+            color:{
+                value:"#ffffff",
+                writable:true,
+                configurable:false,
+                enumerable: true
+            },
+            colorCorrection:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            colorCorrectionSupport:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            },
+            constructor:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            deviceOrientation:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            },
+            displayState:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            focus:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            frameRate:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            fullScreenHeight:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            },
+            fullScreenSourceRect:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            fullScreenWidth:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            },
+            height:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            mouseChildren:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            nativeWindow:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            },
+            numChildren:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            },
+            orientation:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            },
+            quality:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            scaleMode:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            showDefaultContextMenu:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            softKeyboardRect:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            },
+            stageFocusRect:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            stageHeight:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            stageVideos:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            },
+            stageWidth:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
 
-		// ensure the width/height is correct
-		canvas.style.width = canvas.width;
-		canvas.style.height = canvas.height;
+            supportedOrientations:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            },
+            supportsOrientationChange:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            },
+            tabChildren:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            textSnapshot:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            },
+            width:{
+                value:null,
+                writable:true,
+                configurable:false,
+                enumerable:true
+            },
+            wmodeGPU:{
+                value:null,
+                writable:false,
+                configurable:false,
+                enumerable:true
+            }
+        });
+
+        // ensure the width/height is correct
+        canvas.style.width = canvas.width;
+        canvas.style.height = canvas.height;
 
         this.context = canvas.getContext("2d");
 
         this.jcx = new JCX(this._context,0,0);
 
-		// setup click handler
-		var that = this;
-		canvas.onclick = function(e) {
-			that.notifyClick(e);
-		};
+        // setup click handler
+        var that = this;
+        canvas.onclick = function(e) {
+            that.notifyClick(e);
+        };
 
-		// immediately draw the canvas
-		DisplayObjectContainer.prototype.draw.call(this);
-	}
-	
-	Stage.prototype = new DisplayObjectContainer(0, 0);
+        // immediately draw the canvas
+        DisplayObjectContainer.prototype.draw.call(this);
+    }
+    
+    Stage.prototype = new DisplayObjectContainer();
 
-	Stage.prototype._isInBounds = function(x, y) { return true; };
+    Stage.prototype._isInBounds = function(x, y) { return true; };
+
+    //@override
+    Stage.prototype.addChild = function(item){
+        DisplayObjectContainer.prototype.addChild.call(this, item);
+        //TODO
+    };
+
+    //@override
+    Stage.prototype.addChildAt = function(child, index){
+        //TODO what does this override?
+    };
+
+    //@override
+    Stage.prototype.addEventListener = function(type, listener, useCapture, priority, useWeakReference){
+        DisplayObjectContainer.prototype.addEventListener(this, type, listener, useCapture, priority, useWeakReference);
+        //TODO
+    };
+
+    Stage.prototype.assignFocus = function(objectToFocus, direction){
+        //TODO
+    };
+
+    //@override
+    Stage.prototype.dispatchEvent = function(evnt){
+        //TODO
+    };
+
+    //@override
+    Stage.prototype.hasEventListener = function(type){
+        //TODO
+    };
+
+    Stage.prototype.invalidate = function(){
+        //TODO
+    };
+
+    Stage.prototype.isFocusInaccessible = function(){
+        //TODO
+    };
+    //@override
+    Stage.prototype.removeChildAt = function(index){
+        //TODO
+    };
+
+    Stage.prototype.setAspectRatio = function(newAspectRatio){
+        //TODO
+    };
+
+    //@override
+    Stage.prototype.setChildIndex = function(child, index){
+        //TODO
+    };
+
+    Stage.prototype.setOrientation = function(newOrientation){
+        //TODO
+    };
+    
+    //@override
+    Stage.prototype.swapChildrenAt = function(index1, index2){
+        //TODO
+    };
+
+    Stage.prototype.willTrigger = function(type){
+        //TODO
+    };
+
     return Stage;
 });

--- a/src/jcx/StaticText.js
+++ b/src/jcx/StaticText.js
@@ -1,19 +1,10 @@
-define(['jcx/DisplayObject', 'jcx'],function(DisplayObject, JCX){
+define(['jcx/RenderableObject', 'jcx'],function(RenderableObject, JCX){
     "use strict";
 
     function StaticText(){
         //need to do something about this - is duplicated in Shape
         var _jcx;
         Object.defineProperties(this,{
-            jcx: {
-                get: function(){
-                    if(_jcx == null || _jcx == undefined){
-                        _jcx = new JCX(this.context);
-                    }
-                    return _jcx;
-                }
-
-            },
             renderer:{
                 value: null,
                 writable:true,
@@ -28,13 +19,13 @@ define(['jcx/DisplayObject', 'jcx'],function(DisplayObject, JCX){
             }
         });
         
-        DisplayObject.call(this);
+        RenderableObject.call(this);
     }
 
-    StaticText.prototype = new DisplayObject();
+    StaticText.prototype = new RenderableObject();
     StaticText.prototype.draw = function(){
         this.renderer(this.jcx);
-        DisplayObject.prototype.draw.call(this);
+        RenderableObject.prototype.draw.call(this);
     };
 
     return StaticText;

--- a/src/jcx/StaticText.js
+++ b/src/jcx/StaticText.js
@@ -5,12 +5,6 @@ define(['jcx/RenderableObject', 'jcx'],function(RenderableObject, JCX){
         //need to do something about this - is duplicated in Shape
         var _jcx;
         Object.defineProperties(this,{
-            renderer:{
-                value: null,
-                writable:true,
-                configurable:false,
-                enumerable:false
-            },
             text:{
                 value:"",
                 writable:true,

--- a/src/jcx/StaticText.js
+++ b/src/jcx/StaticText.js
@@ -1,0 +1,41 @@
+define(['jcx/DisplayObject', 'jcx'],function(DisplayObject, JCX){
+    "use strict";
+
+    function StaticText(){
+        //need to do something about this - is duplicated in Shape
+        var _jcx;
+        Object.defineProperties(this,{
+            jcx: {
+                get: function(){
+                    if(_jcx == null || _jcx == undefined){
+                        _jcx = new JCX(this.context);
+                    }
+                    return _jcx;
+                }
+
+            },
+            renderer:{
+                value: null,
+                writable:true,
+                configurable:false,
+                enumerable:false
+            },
+            text:{
+                value:"",
+                writable:true,
+                configurable:false,
+                enumerable:true
+            }
+        });
+        
+        DisplayObject.call(this);
+    }
+
+    StaticText.prototype = new DisplayObject();
+    StaticText.prototype.draw = function(){
+        this.renderer(this.jcx);
+        DisplayObject.prototype.draw.call(this);
+    };
+
+    return StaticText;
+});

--- a/src/jcx/sprite.js
+++ b/src/jcx/sprite.js
@@ -1,4 +1,4 @@
-(function(){
+define(['jcx/DisplayObject'], function(DisplayObject){
 
 	"use strict";
 
@@ -47,5 +47,5 @@
 		this._renderer(this.jcx);
 	};
 	
-	window.Sprite = Sprite;
-}());
+    return Sprite;
+});

--- a/src/jcx/sprite.js
+++ b/src/jcx/sprite.js
@@ -5,7 +5,7 @@
 	// using jcx
 	// using jcx/JCXEvent
 
-	function Sprite(context, x, y, renderer, isInBoundsTester) {
+	function Sprite(x, y, renderer, isInBoundsTester) {
 
 		if( typeof(renderer) !== "function" ) {
 			throw new Error("renderer must be a function");
@@ -32,10 +32,10 @@
 		});
 
 
-		DisplayObject.call(this, context, x, y);
+		DisplayObject.call(this, x, y);
 	}
 
-	Sprite.prototype = new DisplayObject(null, 0, 0);
+	Sprite.prototype = new DisplayObject(0, 0);
 	
 	Sprite.prototype._isInBounds = function(x, y) {
 		return this._isInBoundsTester.call(this, x, y);
@@ -44,7 +44,7 @@
 	//@override
 	Sprite.prototype.draw = function() {
 		DisplayObject.prototype.draw.call(this);
-		this._renderer.call(this, this.jcx);
+		this._renderer(this.jcx);
 	};
 	
 	window.Sprite = Sprite;

--- a/src/jcx/sprite.js
+++ b/src/jcx/sprite.js
@@ -2,51 +2,11 @@ define(['jcx/DisplayObjectContainer'], function(DisplayObjectContainer){
 
 	"use strict";
 
-	// using jcx
-	// using jcx/JCXEvent
-
-	function Sprite(x, y, renderer, isInBoundsTester) {
-
-		if( typeof(renderer) !== "function" ) {
-			throw new Error("renderer must be a function");
-		}
-
-		if( typeof(isInBoundsTester) !== "function" ) {
-			throw new Error("isInBoundsTester must be a function");
-		}
-
-		Object.defineProperties(this,
-		{
-			_renderer : {
-				value: renderer,
-				writable: false,
-				configurable: false,
-				enumerable: false
-			},
-			_isInBoundsTester : {
-				value : isInBoundsTester,
-				writable: false,
-				configurable : false,
-				enumerable : false
-			}
-		});
-
+	function Sprite() {
 		DisplayObjectContainer.call(this);
-        this.x = x;
-        this.y = y;
 	}
 
-	Sprite.prototype = new DisplayObjectContainer(0, 0);
-	
-	Sprite.prototype._isInBounds = function(x, y) {
-		return this._isInBoundsTester.call(this, x, y);
-	};
-
-	//@override
-	Sprite.prototype.draw = function() {
-		this._renderer(this.jcx);
-		DisplayObjectContainer.prototype.draw.call(this);
-	};
+	Sprite.prototype = new DisplayObjectContainer();
 	
     return Sprite;
 });

--- a/src/jcx/sprite.js
+++ b/src/jcx/sprite.js
@@ -1,4 +1,4 @@
-define(['jcx/DisplayObject'], function(DisplayObject){
+define(['jcx/DisplayObjectContainer'], function(DisplayObjectContainer){
 
 	"use strict";
 
@@ -31,11 +31,12 @@ define(['jcx/DisplayObject'], function(DisplayObject){
 			}
 		});
 
-
-		DisplayObject.call(this, x, y);
+		DisplayObjectContainer.call(this);
+        this.x = x;
+        this.y = y;
 	}
 
-	Sprite.prototype = new DisplayObject(0, 0);
+	Sprite.prototype = new DisplayObjectContainer(0, 0);
 	
 	Sprite.prototype._isInBounds = function(x, y) {
 		return this._isInBoundsTester.call(this, x, y);
@@ -43,8 +44,8 @@ define(['jcx/DisplayObject'], function(DisplayObject){
 
 	//@override
 	Sprite.prototype.draw = function() {
-		DisplayObject.prototype.draw.call(this);
 		this._renderer(this.jcx);
+		DisplayObjectContainer.prototype.draw.call(this);
 	};
 	
     return Sprite;

--- a/src/jcx/sprite.js
+++ b/src/jcx/sprite.js
@@ -2,11 +2,35 @@ define(['jcx/DisplayObjectContainer'], function(DisplayObjectContainer){
 
 	"use strict";
 
+	var _isBeingDragged = false;
+	var _isBeingTouchDragged = false;
 	function Sprite() {
+        Object.defineProperties(this, {
+            isBeingDragged:{
+                get:function(){return _isBeingDragged;},
+                configurable:false,
+                enumerable:false
+            }
+        });
 		DisplayObjectContainer.call(this);
 	}
 
 	Sprite.prototype = new DisplayObjectContainer();
 	
+	Sprite.prototype.startDrag = function(lockCenter, bounds){
+		_isBeingDragged = true;
+	};
+
+	Sprite.prototype.startTouchDrag = function(touchPointID, lockCenter, bounds){
+		_isBeingTouchDragged= true;
+	};
+
+	Sprite.prototype.stopDrag = function(){
+		_isBeingDragged = false;
+	};
+
+	Sprite.prototype.stopTouchDrag = function(){
+		_isBeingTouchDragged = false;
+	};
     return Sprite;
 });

--- a/src/jcx/sprite.js
+++ b/src/jcx/sprite.js
@@ -1,36 +1,36 @@
 define(['jcx/DisplayObjectContainer'], function(DisplayObjectContainer){
 
-	"use strict";
+    "use strict";
 
-	var _isBeingDragged = false;
-	var _isBeingTouchDragged = false;
-	function Sprite() {
+    function Sprite() {
+        this._isBeingTouchDragged = false;
+        this._isBeingDragged = false;
         Object.defineProperties(this, {
             isBeingDragged:{
-                get:function(){return _isBeingDragged;},
+                get:function(){return this._isBeingDragged;},
                 configurable:false,
                 enumerable:false
             }
         });
-		DisplayObjectContainer.call(this);
-	}
+        DisplayObjectContainer.call(this);
+    }
 
-	Sprite.prototype = new DisplayObjectContainer();
-	
-	Sprite.prototype.startDrag = function(lockCenter, bounds){
-		_isBeingDragged = true;
-	};
+    Sprite.prototype = new DisplayObjectContainer();
+    
+    Sprite.prototype.startDrag = function(lockCenter, bounds){
+        this._isBeingDragged = true;
+    };
 
-	Sprite.prototype.startTouchDrag = function(touchPointID, lockCenter, bounds){
-		_isBeingTouchDragged= true;
-	};
+    Sprite.prototype.startTouchDrag = function(touchPointID, lockCenter, bounds){
+        this._isBeingTouchDragged= true;
+    };
 
-	Sprite.prototype.stopDrag = function(){
-		_isBeingDragged = false;
-	};
+    Sprite.prototype.stopDrag = function(){
+        this._isBeingDragged = false;
+    };
 
-	Sprite.prototype.stopTouchDrag = function(){
-		_isBeingTouchDragged = false;
-	};
+    Sprite.prototype.stopTouchDrag = function(){
+        this._isBeingTouchDragged = false;
+    };
     return Sprite;
 });

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,4 @@
+require.config({
+});
+
+require(["jcx/DisplayObjectContainer", "jcx/sprite", "jcx/Stage", "jcx/JCXEvent"]);


### PR DESCRIPTION
added
-text
-shapes
-more robust event handling
-drag-able objects

still needs some more restructuring

I have a plan for restructuring the event system, specifically - it needs to pick the event "target" properly, and navigate the path from stage to display object more directly by creating a few classes to handle caching of that path after initial click.

-at the moment, inheritors of the display object class create their own JCX object by traversing the tree for a reference to the canvas context - need to figure out best way to deal with that, create a single reference for jcx and avoid traversing the tree for the context
